### PR TITLE
Claude/add blogsummary filters 011 c ux swk mw p fi zk hdzb fppb

### DIFF
--- a/Mostlylucid/Views/Shared/_BlogSummaryList.cshtml
+++ b/Mostlylucid/Views/Shared/_BlogSummaryList.cshtml
@@ -52,20 +52,6 @@
         </div>
     </div>
 
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
-<style>
-/* Theme-aware overrides for Flatpickr in dark mode */
-html.dark .flatpickr-calendar { background-color: #1f2937 !important; color: #e5e7eb !important; border-color: #374151 !important; }
-html.dark .flatpickr-months, html.dark .flatpickr-weekdays { background-color: #111827 !important; border-color: #374151 !important; color: #e5e7eb !important; }
-html.dark .flatpickr-day { color: #e5e7eb !important; }
-html.dark .flatpickr-day:hover { background-color: #374151 !important; }
-html.dark .flatpickr-day.today { border-color: #60a5fa !important; }
-html.dark .flatpickr-day.selected, 
-html.dark .flatpickr-day.startRange, 
-html.dark .flatpickr-day.endRange, 
-html.dark .flatpickr-day.inRange { background-color: #2563eb !important; border-color: #2563eb !important; color: #ffffff !important; }
-</style>
-<script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
     @if (ViewBag.Categories != null)
     {
         <div class="mb-8 mt-6" x-data="blogCategories()">

--- a/Mostlylucid/Views/Shared/_LanguageDropDown.cshtml
+++ b/Mostlylucid/Views/Shared/_LanguageDropDown.cshtml
@@ -42,35 +42,37 @@
 }
 
 <div id="LanguageDropDown"
+     data-languages='@Html.Raw(optsJson)'
+     data-language-map='@Html.Raw(langMapJson)'
      x-data="{
         open: false,
         selectedLanguage: 'Select Language',
         selectedFlag: '',
-        selectedShortCode: ''
+        selectedShortCode: '',
+        init() {
+            // Initialize from URL param or default to 'en'
+            const url = new URL(window.location.href);
+            const fromUrl = (url.searchParams.get('language') || 'en').toLowerCase();
+            const opts = JSON.parse(this.$el.dataset.languages || '[]');
+            const has = opts.includes(fromUrl) ? fromUrl : (opts.includes('en') ? 'en' : (opts[0] || 'en'));
+            this.selectedShortCode = has;
+            const labelMap = JSON.parse(this.$el.dataset.languageMap || '{}');
+            this.selectedLanguage = labelMap[has] || 'Select Language';
+            this.selectedFlag = `/img/flags/${has}.svg`;
+            // Set hidden input value only (don't navigate on init)
+            const hidden = document.getElementById('languageSelect');
+            if (hidden) { hidden.value = has; }
+            // Watch for changes and emit 'change' for external listeners
+            this.$watch('selectedShortCode', (val) => {
+                if (!val) return;
+                const el = document.getElementById('languageSelect');
+                if (el) {
+                    el.value = val;
+                    el.dispatchEvent(new Event('change'));
+                }
+            });
+        }
      }"
-     x-init="(() => {
-        // Initialize from URL param or default to 'en'
-        const url = new URL(window.location.href);
-        const fromUrl = (url.searchParams.get('language') || 'en').toLowerCase();
-        const opts = @Html.Raw(optsJson);
-        const has = opts.includes(fromUrl) ? fromUrl : (opts.includes('en') ? 'en' : (opts[0] || 'en'));
-        selectedShortCode = has;
-        const labelMap = @Html.Raw(langMapJson);
-        selectedLanguage = labelMap[has] || 'Select Language';
-        selectedFlag = `/img/flags/${has}.svg`;
-        // Set hidden input value only (don't navigate on init)
-        const hidden = document.getElementById('languageSelect');
-        if (hidden){ hidden.value = has; }
-        // Watch for changes and emit 'change' for external listeners
-        $watch('selectedShortCode', (val) => {
-          if (!val) return;
-          const el = document.getElementById('languageSelect');
-          if (el){
-            el.value = val;
-            el.dispatchEvent(new Event('change'));
-          }
-        });
-     })()"
      class="relative inline-block">
     <!-- Hidden input used by existing JS listeners -->
     <input type="hidden" id="languageSelect" />

--- a/Mostlylucid/package-lock.json
+++ b/Mostlylucid/package-lock.json
@@ -9,6 +9,7 @@
         "codemirror": "5.65.13",
         "core-js": "^3.39.0",
         "easymde": "2.20.0",
+        "flatpickr": "^4.6.13",
         "highlight.js": "^11.10.0",
         "highlightjs-cshtml-razor": "^2.1.1",
         "html-to-image": "^1.11.13",
@@ -127,7 +128,6 @@
       "integrity": "sha512-lWBYIrF7qK5+GjY5Uy+/hEgp8OJWOD/rpy74GplYRhEauvbHDeFB8t5hPOZxCZ0Oxf4Cc36tK51/l3ymJysrKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -2978,7 +2978,6 @@
       "integrity": "sha512-uKXqKN9beGoMdBfcaTY1ecwz6ctxuJAcUlwE55938g0ZJ8lRxwAZqRz2AJ4pzpt5dHdTPMB863UZ0ESiFUcP7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3443,7 +3442,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -4016,7 +4014,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -4209,7 +4206,6 @@
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
       "integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "11.0.3",
         "@chevrotain/gast": "11.0.3",
@@ -5357,7 +5353,6 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.31.2.tgz",
       "integrity": "sha512-/eOXg2uGdMdpGlEes5Sf6zE+jUG+05f3htFNQIxLxduOH/SsaUZiPBfAwP1btVIVzsnhiNOdi+hvDRLYfMZjGw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -5767,7 +5762,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -6822,6 +6816,12 @@
         "flat": "cli.js"
       }
     },
+    "node_modules/flatpickr": {
+      "version": "4.6.13",
+      "resolved": "https://registry.npmjs.org/flatpickr/-/flatpickr-4.6.13.tgz",
+      "integrity": "sha512-97PMG/aywoYpB4IvbvUJi0RQi8vearvU0oov1WW3k0WZPBMrTQVqekSX5CjSG/M4Q3i6A/0FKXC7RyAoAUUSPw==",
+      "license": "MIT"
+    },
     "node_modules/flatted": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
@@ -7328,7 +7328,6 @@
       "integrity": "sha512-KyrFvnl+J9US63TEzwoiJOQzZBJY7KgBushJA8X61DMbNsH+2ONkDuLDnCnwUiPTF42tLoEmrPyoqbenVA5zrg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "entities": "^4.5.0",
         "webidl-conversions": "^7.0.0",
@@ -8337,7 +8336,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -9665,7 +9663,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.8",
         "picocolors": "^1.1.1",
@@ -12202,7 +12199,6 @@
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -12332,7 +12328,6 @@
       "integrity": "sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",
@@ -12510,7 +12505,6 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12974,7 +12968,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -13065,7 +13058,6 @@
       "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "2.1.9",
         "@vitest/mocker": "2.1.9",
@@ -13212,7 +13204,6 @@
       "integrity": "sha512-CNqKBRMQjwcmKR0idID5va1qlhrqVUKpovi+Ec79ksW8ux7iS1+A6VqzfZXgVYCFRKl7XL5ap3ZoMpwBJxcg0w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
@@ -13261,7 +13252,6 @@
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",

--- a/Mostlylucid/package.json
+++ b/Mostlylucid/package.json
@@ -53,6 +53,7 @@
     "codemirror": "5.65.13",
     "core-js": "^3.39.0",
     "easymde": "2.20.0",
+    "flatpickr": "^4.6.13",
     "highlight.js": "^11.10.0",
     "highlightjs-cshtml-razor": "^2.1.1",
     "html-to-image": "^1.11.13",

--- a/Mostlylucid/src/css/flatpickr-overrides.css
+++ b/Mostlylucid/src/css/flatpickr-overrides.css
@@ -1,0 +1,153 @@
+/* Flatpickr Dark Mode Overrides */
+/* Ensures proper contrast and readability in dark mode */
+
+/* Dark mode calendar container */
+html.dark .flatpickr-calendar {
+    background-color: #1f2937 !important;
+    color: #e5e7eb !important;
+    border-color: #374151 !important;
+    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.3), 0 4px 6px -2px rgba(0, 0, 0, 0.2) !important;
+}
+
+/* Dark mode months header and weekdays */
+html.dark .flatpickr-months,
+html.dark .flatpickr-weekdays {
+    background-color: #111827 !important;
+    border-color: #374151 !important;
+    color: #e5e7eb !important;
+}
+
+/* Dark mode month navigation arrows */
+html.dark .flatpickr-months .flatpickr-prev-month,
+html.dark .flatpickr-months .flatpickr-next-month {
+    color: #e5e7eb !important;
+    fill: #e5e7eb !important;
+}
+
+html.dark .flatpickr-months .flatpickr-prev-month:hover,
+html.dark .flatpickr-months .flatpickr-next-month:hover {
+    color: #60a5fa !important;
+    fill: #60a5fa !important;
+}
+
+/* Dark mode current month text */
+html.dark .flatpickr-current-month {
+    color: #e5e7eb !important;
+}
+
+html.dark .flatpickr-current-month .flatpickr-monthDropdown-months {
+    background-color: #1f2937 !important;
+    color: #e5e7eb !important;
+}
+
+html.dark .flatpickr-current-month .numInputWrapper input {
+    background-color: #1f2937 !important;
+    color: #e5e7eb !important;
+}
+
+/* Dark mode weekday names */
+html.dark .flatpickr-weekday {
+    color: #9ca3af !important;
+    font-weight: 600;
+}
+
+/* Dark mode day cells */
+html.dark .flatpickr-day {
+    color: #e5e7eb !important;
+    border-color: transparent !important;
+}
+
+html.dark .flatpickr-day:hover {
+    background-color: #374151 !important;
+    color: #ffffff !important;
+    border-color: #374151 !important;
+}
+
+/* Dark mode today indicator */
+html.dark .flatpickr-day.today {
+    border-color: #60a5fa !important;
+    background-color: #1e40af !important;
+    color: #ffffff !important;
+}
+
+html.dark .flatpickr-day.today:hover {
+    background-color: #1e3a8a !important;
+    border-color: #60a5fa !important;
+    color: #ffffff !important;
+}
+
+/* Dark mode selected dates */
+html.dark .flatpickr-day.selected,
+html.dark .flatpickr-day.startRange,
+html.dark .flatpickr-day.endRange {
+    background-color: #2563eb !important;
+    border-color: #2563eb !important;
+    color: #ffffff !important;
+}
+
+html.dark .flatpickr-day.selected:hover,
+html.dark .flatpickr-day.startRange:hover,
+html.dark .flatpickr-day.endRange:hover {
+    background-color: #1d4ed8 !important;
+    border-color: #1d4ed8 !important;
+    color: #ffffff !important;
+}
+
+/* Dark mode range dates (between start and end) */
+html.dark .flatpickr-day.inRange {
+    background-color: #1e3a8a !important;
+    border-color: transparent !important;
+    color: #e5e7eb !important;
+    box-shadow: -5px 0 0 #1e3a8a, 5px 0 0 #1e3a8a !important;
+}
+
+html.dark .flatpickr-day.inRange:hover {
+    background-color: #1e40af !important;
+    color: #ffffff !important;
+}
+
+/* Dark mode disabled/out-of-range days */
+html.dark .flatpickr-day.flatpickr-disabled,
+html.dark .flatpickr-day.prevMonthDay,
+html.dark .flatpickr-day.nextMonthDay {
+    color: #4b5563 !important;
+}
+
+html.dark .flatpickr-day.flatpickr-disabled:hover {
+    background-color: transparent !important;
+    color: #4b5563 !important;
+    cursor: not-allowed;
+}
+
+/* Dark mode time picker (if enabled) */
+html.dark .flatpickr-time {
+    border-color: #374151 !important;
+}
+
+html.dark .flatpickr-time input {
+    background-color: #1f2937 !important;
+    color: #e5e7eb !important;
+}
+
+html.dark .flatpickr-time .flatpickr-time-separator,
+html.dark .flatpickr-time .flatpickr-am-pm {
+    color: #e5e7eb !important;
+}
+
+/* Dark mode custom styles for calendar with posts (from blog-index.js) */
+html.dark .flatpickr-day.has-post {
+    background: rgba(76, 175, 80, 0.35) !important;
+    border-radius: 6px;
+    color: #ffffff !important;
+}
+
+html.dark .flatpickr-day.has-post.selected,
+html.dark .flatpickr-day.has-post.startRange,
+html.dark .flatpickr-day.has-post.endRange {
+    background-color: #2563eb !important;
+}
+
+/* Ensure proper text contrast on all interactive elements */
+html.dark .flatpickr-calendar * {
+    box-sizing: border-box;
+}

--- a/Mostlylucid/src/js/main.js
+++ b/Mostlylucid/src/js/main.js
@@ -8,8 +8,12 @@ import hljs from "highlight.js";
 import EasyMDE from "easymde";
 import 'easymde/dist/easymde.min.css';
 import '../css/easymde-overrides.css';
+import flatpickr from "flatpickr";
+import 'flatpickr/dist/flatpickr.min.css';
+import '../css/flatpickr-overrides.css';
 
 window.EasyMDE = EasyMDE;
+window.flatpickr = flatpickr;
 
 window.Alpine = Alpine;
 window.hljs=hljs;


### PR DESCRIPTION
This pull request introduces improvements to how the Flatpickr date picker is integrated and styled, especially for dark mode, and refactors the language dropdown initialization for better maintainability and performance. It also adds Flatpickr as an npm dependency and cleans up related asset management.

**Flatpickr Integration and Dark Mode Styling:**

* Added `flatpickr` as an npm dependency in both `package.json` and `package-lock.json`, ensuring it is managed via the package manager instead of CDN. [[1]](diffhunk://#diff-e158bcbdb6da1e7deef25cd1d28bfe67f2c0ec2c66908a925694f16d5b69bdf6R56) [[2]](diffhunk://#diff-6adbe91a3ab0136e76cdd133391573c6913e3eda63d127ffc9d0127b7817d0ddR12) [[3]](diffhunk://#diff-6adbe91a3ab0136e76cdd133391573c6913e3eda63d127ffc9d0127b7817d0ddR6819-R6824)
* Removed the CDN-based Flatpickr import and inline dark mode styles from `_BlogSummaryList.cshtml`.
* Created a new `flatpickr-overrides.css` file with comprehensive dark mode styles for the Flatpickr calendar, improving readability and theme consistency.
* Updated `main.js` to import Flatpickr and its CSS from npm, and to expose it on the `window` object for global usage.

**Language Dropdown Refactor:**

* Refactored the Alpine.js initialization in `_LanguageDropDown.cshtml` to use `data-` attributes for passing language options and label maps as JSON, and moved the initialization logic into an `init()` method for clarity and maintainability.

**Dependency Management Cleanup:**

* Removed unnecessary `"peer": true` flags from various dependencies in `package-lock.json`, reducing noise and potential confusion in dependency metadata. [[1]](diffhunk://#diff-6adbe91a3ab0136e76cdd133391573c6913e3eda63d127ffc9d0127b7817d0ddL130) [[2]](diffhunk://#diff-6adbe91a3ab0136e76cdd133391573c6913e3eda63d127ffc9d0127b7817d0ddL2981) [[3]](diffhunk://#diff-6adbe91a3ab0136e76cdd133391573c6913e3eda63d127ffc9d0127b7817d0ddL3446) [[4]](diffhunk://#diff-6adbe91a3ab0136e76cdd133391573c6913e3eda63d127ffc9d0127b7817d0ddL4019) [[5]](diffhunk://#diff-6adbe91a3ab0136e76cdd133391573c6913e3eda63d127ffc9d0127b7817d0ddL4212) [[6]](diffhunk://#diff-6adbe91a3ab0136e76cdd133391573c6913e3eda63d127ffc9d0127b7817d0ddL5360) [[7]](diffhunk://#diff-6adbe91a3ab0136e76cdd133391573c6913e3eda63d127ffc9d0127b7817d0ddL5770) [[8]](diffhunk://#diff-6adbe91a3ab0136e76cdd133391573c6913e3eda63d127ffc9d0127b7817d0ddL7331) [[9]](diffhunk://#diff-6adbe91a3ab0136e76cdd133391573c6913e3eda63d127ffc9d0127b7817d0ddL8340) [[10]](diffhunk://#diff-6adbe91a3ab0136e76cdd133391573c6913e3eda63d127ffc9d0127b7817d0ddL9668) [[11]](diffhunk://#diff-6adbe91a3ab0136e76cdd133391573c6913e3eda63d127ffc9d0127b7817d0ddL12205) [[12]](diffhunk://#diff-6adbe91a3ab0136e76cdd133391573c6913e3eda63d127ffc9d0127b7817d0ddL12335) [[13]](diffhunk://#diff-6adbe91a3ab0136e76cdd133391573c6913e3eda63d127ffc9d0127b7817d0ddL12513) [[14]](diffhunk://#diff-6adbe91a3ab0136e76cdd133391573c6913e3eda63d127ffc9d0127b7817d0ddL12977) [[15]](diffhunk://#diff-6adbe91a3ab0136e76cdd133391573c6913e3eda63d127ffc9d0127b7817d0ddL13068) [[16]](diffhunk://#diff-6adbe91a3ab0136e76cdd133391573c6913e3eda63d127ffc9d0127b7817d0ddL13215) [[17]](diffhunk://#diff-6adbe91a3ab0136e76cdd133391573c6913e3eda63d127ffc9d0127b7817d0ddL13264)