### PR TITLE
Integrate fetch preprocessor into blogllm ingestion pipeline

### DIFF
--- a/Mostlylucid/Markdown/building-a-lawyer-gpt-for-your-blog-part4.md
+++ b/Mostlylucid/Markdown/building-a-lawyer-gpt-for-your-blog-part4.md
@@ -379,6 +379,134 @@ namespace Mostlylucid.BlogLLM.Core.Services
 - Computes hash for change detection
 - Handles translated files (e.g., `slug.es.md`)
 
+### Markdown Fetch Preprocessing
+
+Before parsing, we use the **Markdown Fetch Extension** to process any `<fetch>` tags in the markdown. This allows blog posts to include remote content dynamically!
+
+For example, if your markdown contains:
+```markdown
+<fetch markdownurl="https://example.com/api-docs.md" pollfrequency="24h" />
+```
+
+The preprocessor will:
+1. Fetch the remote markdown from the URL
+2. Cache it in memory (for the duration of ingestion)
+3. Replace the tag with the actual content
+4. Then parse everything together
+
+**Updated Parser with Fetch Support**:
+
+```csharp
+using Mostlylucid.Markdig.FetchExtension.Processors;
+using Microsoft.Extensions.Logging;
+
+public class MarkdownParserService
+{
+    private readonly MarkdownPipeline _pipeline;
+    private readonly IServiceProvider? _serviceProvider;
+    private readonly ILogger<MarkdownParserService>? _logger;
+
+    public MarkdownParserService(
+        IServiceProvider? serviceProvider = null,
+        ILogger<MarkdownParserService>? logger = null)
+    {
+        _serviceProvider = serviceProvider;
+        _logger = logger;
+        _pipeline = new MarkdownPipelineBuilder()
+            .UseAdvancedExtensions()
+            .Build();
+    }
+
+    public BlogPost ParseMarkdownFile(string filePath)
+    {
+        var markdown = File.ReadAllText(filePath);
+        var fileName = Path.GetFileNameWithoutExtension(filePath);
+
+        // Preprocess markdown to fetch remote content if there are <fetch> tags
+        if (_serviceProvider != null)
+        {
+            var preprocessor = new MarkdownFetchPreprocessor(_serviceProvider, _logger);
+            markdown = preprocessor.Preprocess(markdown);
+            _logger?.LogInformation("Preprocessed {File} for fetch tags", filePath);
+        }
+
+        // Now parse the (potentially expanded) markdown
+        var document = Markdown.Parse(markdown, _pipeline);
+        // ... rest of parsing logic
+    }
+}
+```
+
+**Simple Fetch Service for Ingestion**:
+
+Since the ingestion tool doesn't need database persistence, we use a simple in-memory implementation:
+
+```csharp
+using Mostlylucid.Markdig.FetchExtension.Services;
+using Mostlylucid.Markdig.FetchExtension.Models;
+
+public class SimpleMarkdownFetchService : IMarkdownFetchService
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ConcurrentDictionary<string, (string content, DateTimeOffset fetchedAt)> _cache = new();
+
+    public SimpleMarkdownFetchService(IHttpClientFactory httpClientFactory)
+    {
+        _httpClientFactory = httpClientFactory;
+    }
+
+    public async Task<MarkdownFetchResult> FetchMarkdownAsync(
+        string url, int pollFrequencyHours, int blogPostId)
+    {
+        // Check cache first
+        if (_cache.TryGetValue(url, out var cached))
+        {
+            var age = DateTimeOffset.UtcNow - cached.fetchedAt;
+            if (age.TotalHours < pollFrequencyHours)
+            {
+                return new MarkdownFetchResult { Success = true, Content = cached.content };
+            }
+        }
+
+        // Fetch fresh content
+        var client = _httpClientFactory.CreateClient();
+        client.Timeout = TimeSpan.FromSeconds(30);
+        var response = await client.GetAsync(url);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            // Return cached content if available
+            if (_cache.TryGetValue(url, out var staleCached))
+            {
+                return new MarkdownFetchResult { Success = true, Content = staleCached.content };
+            }
+            return new MarkdownFetchResult
+            {
+                Success = false,
+                ErrorMessage = $"HTTP {(int)response.StatusCode}: {response.ReasonPhrase}"
+            };
+        }
+
+        var content = await response.Content.ReadAsStringAsync();
+        _cache[url] = (content, DateTimeOffset.UtcNow);
+
+        return new MarkdownFetchResult { Success = true, Content = content };
+    }
+
+    public Task<bool> RemoveCachedMarkdownAsync(string url, int blogPostId = 0)
+    {
+        var removed = _cache.TryRemove(url, out _);
+        return Task.FromResult(removed);
+    }
+}
+```
+
+**Benefits**:
+- Blog posts can reference external API documentation, shared content, or other markdown files
+- Content is fetched once per ingestion run and cached
+- Falls back to cached content if remote fetch fails
+- Embeddings include both local and remote content
+
 ## Intelligent Chunking Strategy
 
 This is critical! Bad chunking = bad search results.
@@ -1267,7 +1395,11 @@ builder.Services.AddSerilog();
 // Configure settings
 builder.Services.Configure<IngestionConfig>(builder.Configuration.GetSection("Ingestion"));
 
-// Register services
+// Register markdown fetch service for preprocessing
+builder.Services.AddHttpClient();
+builder.Services.AddSingleton<IMarkdownFetchService, SimpleMarkdownFetchService>();
+
+// Register services (MarkdownParserService now gets IServiceProvider injected)
 builder.Services.AddSingleton<MarkdownParserService>();
 builder.Services.AddSingleton(sp =>
 {

--- a/mostlylucid.blogllm/Program.cs
+++ b/mostlylucid.blogllm/Program.cs
@@ -1,6 +1,9 @@
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Mostlylucid.BlogLLM.Models;
 using Mostlylucid.BlogLLM.Services;
+using Mostlylucid.Markdig.FetchExtension.Services;
 using Spectre.Console;
 using System.Diagnostics;
 
@@ -9,6 +12,7 @@ namespace Mostlylucid.BlogLLM;
 class Program
 {
     private static IConfiguration? _config;
+    private static IServiceProvider? _serviceProvider;
     private static string _modelPath = string.Empty;
     private static string _tokenizerPath = string.Empty;
     private static int _dimensions = 384;
@@ -84,6 +88,13 @@ class Program
         _maxChunkTokens = int.Parse(section["Chunking:MaxChunkTokens"] ?? "512");
         _minChunkTokens = int.Parse(section["Chunking:MinChunkTokens"] ?? "100");
         _overlapTokens = int.Parse(section["Chunking:OverlapTokens"] ?? "50");
+
+        // Setup dependency injection for markdown fetch service
+        var services = new ServiceCollection();
+        services.AddHttpClient();
+        services.AddLogging(builder => builder.AddConsole());
+        services.AddSingleton<IMarkdownFetchService, SimpleMarkdownFetchService>();
+        _serviceProvider = services.BuildServiceProvider();
     }
 
     static string ShowMainMenu()
@@ -148,7 +159,8 @@ class Program
 
                 // Initialize services
                 AnsiConsole.MarkupLine("[dim]Initializing services...[/]");
-                var parser = new MarkdownParserService();
+                var logger = _serviceProvider?.GetService<ILogger<MarkdownParserService>>();
+                var parser = new MarkdownParserService(_serviceProvider, logger);
                 var chunker = new ChunkingService(_tokenizerPath, _maxChunkTokens, _minChunkTokens, _overlapTokens);
 
                 using var embedder = new EmbeddingService(_modelPath, _tokenizerPath, _dimensions, _useGpu);

--- a/mostlylucid.blogllm/Services/MarkdownParserService.cs
+++ b/mostlylucid.blogllm/Services/MarkdownParserService.cs
@@ -1,7 +1,9 @@
 using Markdig;
 using Markdig.Syntax;
 using Markdig.Syntax.Inlines;
+using Microsoft.Extensions.Logging;
 using Mostlylucid.BlogLLM.Models;
+using Mostlylucid.Markdig.FetchExtension.Processors;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -11,9 +13,13 @@ namespace Mostlylucid.BlogLLM.Services;
 public class MarkdownParserService
 {
     private readonly MarkdownPipeline _pipeline;
+    private readonly IServiceProvider? _serviceProvider;
+    private readonly ILogger<MarkdownParserService>? _logger;
 
-    public MarkdownParserService()
+    public MarkdownParserService(IServiceProvider? serviceProvider = null, ILogger<MarkdownParserService>? logger = null)
     {
+        _serviceProvider = serviceProvider;
+        _logger = logger;
         _pipeline = new MarkdownPipelineBuilder()
             .UseAdvancedExtensions()
             .Build();
@@ -23,6 +29,14 @@ public class MarkdownParserService
     {
         var markdown = File.ReadAllText(filePath);
         var fileName = Path.GetFileNameWithoutExtension(filePath);
+
+        // Preprocess markdown to fetch remote content if there are <fetch> tags
+        if (_serviceProvider != null)
+        {
+            var preprocessor = new MarkdownFetchPreprocessor(_serviceProvider, _logger);
+            markdown = preprocessor.Preprocess(markdown);
+            _logger?.LogInformation("Preprocessed markdown file {FilePath} for fetch tags", filePath);
+        }
 
         var document = Markdown.Parse(markdown, _pipeline);
 

--- a/mostlylucid.blogllm/Services/SimpleMarkdownFetchService.cs
+++ b/mostlylucid.blogllm/Services/SimpleMarkdownFetchService.cs
@@ -1,0 +1,115 @@
+using Mostlylucid.Markdig.FetchExtension.Models;
+using Mostlylucid.Markdig.FetchExtension.Services;
+using System.Collections.Concurrent;
+
+namespace Mostlylucid.BlogLLM.Services;
+
+/// <summary>
+/// Simple in-memory implementation of IMarkdownFetchService for the blogllm ingestion tool.
+/// Does not persist to database, just fetches and caches in memory for the duration of the run.
+/// </summary>
+public class SimpleMarkdownFetchService : IMarkdownFetchService
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ConcurrentDictionary<string, (string content, DateTimeOffset fetchedAt)> _cache = new();
+
+    public SimpleMarkdownFetchService(IHttpClientFactory httpClientFactory)
+    {
+        _httpClientFactory = httpClientFactory;
+    }
+
+    public async Task<MarkdownFetchResult> FetchMarkdownAsync(string url, int pollFrequencyHours, int blogPostId)
+    {
+        try
+        {
+            // Check cache first
+            if (_cache.TryGetValue(url, out var cached))
+            {
+                var age = DateTimeOffset.UtcNow - cached.fetchedAt;
+                if (age.TotalHours < pollFrequencyHours)
+                {
+                    return new MarkdownFetchResult
+                    {
+                        Success = true,
+                        Content = cached.content
+                    };
+                }
+            }
+
+            // Fetch fresh content
+            var client = _httpClientFactory.CreateClient();
+            client.Timeout = TimeSpan.FromSeconds(30);
+
+            var response = await client.GetAsync(url);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                // Return cached content if available
+                if (_cache.TryGetValue(url, out var staleCached))
+                {
+                    return new MarkdownFetchResult
+                    {
+                        Success = true,
+                        Content = staleCached.content
+                    };
+                }
+
+                return new MarkdownFetchResult
+                {
+                    Success = false,
+                    ErrorMessage = $"HTTP {(int)response.StatusCode}: {response.ReasonPhrase}"
+                };
+            }
+
+            var content = await response.Content.ReadAsStringAsync();
+
+            if (string.IsNullOrWhiteSpace(content))
+            {
+                return new MarkdownFetchResult
+                {
+                    Success = false,
+                    ErrorMessage = "Fetched content was empty"
+                };
+            }
+
+            // Cache the content
+            _cache[url] = (content, DateTimeOffset.UtcNow);
+
+            return new MarkdownFetchResult
+            {
+                Success = true,
+                Content = content
+            };
+        }
+        catch (TaskCanceledException)
+        {
+            return new MarkdownFetchResult
+            {
+                Success = false,
+                ErrorMessage = "Request timed out after 30 seconds"
+            };
+        }
+        catch (HttpRequestException ex)
+        {
+            return new MarkdownFetchResult
+            {
+                Success = false,
+                ErrorMessage = $"HTTP request failed: {ex.Message}"
+            };
+        }
+        catch (Exception ex)
+        {
+            return new MarkdownFetchResult
+            {
+                Success = false,
+                ErrorMessage = $"Fetch error: {ex.Message}"
+            };
+        }
+    }
+
+    public Task<bool> RemoveCachedMarkdownAsync(string url, int blogPostId = 0)
+    {
+        var removed = _cache.TryRemove(url, out _);
+        return Task.FromResult(removed);
+    }
+}

--- a/mostlylucid.blogllm/mostlylucid.blogllm.csproj
+++ b/mostlylucid.blogllm/mostlylucid.blogllm.csproj
@@ -21,6 +21,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Mostlylucid.Markdig.FetchExtension\Mostlylucid.Markdig.FetchExtension.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Update="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
- Add reference to Mostlylucid.Markdig.FetchExtension project
- Create SimpleMarkdownFetchService for in-memory fetch caching
- Update MarkdownParserService to preprocess fetch tags before parsing
- Register IMarkdownFetchService in DI container
- Update Part 4 article to document fetch preprocessing feature

This allows markdown files in the ingestion pipeline to include remote content via <fetch markdownurl="..." pollfrequency="..." /> tags, which are fetched and inlined before chunking and embedding.