### PR TITLE
Skip inlining dynamic shields.io images

### DIFF
--- a/Mostlylucid.Services/Images/ExternalImageDownloadService.cs
+++ b/Mostlylucid.Services/Images/ExternalImageDownloadService.cs
@@ -236,6 +236,14 @@ public partial class ExternalImageDownloadService
             if (Uri.TryCreate(url, UriKind.Absolute, out var uri) &&
                 (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps))
             {
+                // Skip shields.io badges - they are dynamic and should never be inlined
+                if (uri.Host.Equals("shields.io", StringComparison.OrdinalIgnoreCase) ||
+                    uri.Host.EndsWith(".shields.io", StringComparison.OrdinalIgnoreCase))
+                {
+                    _logger.LogDebug("Skipping shields.io badge: {Url}", url);
+                    continue;
+                }
+
                 externalUrls.Add(url);
             }
         }


### PR DESCRIPTION
- Add exception in ExternalImageDownloadService to skip shields.io URLs
- Shields.io badges are dynamic and should never be cached locally
- Checks for both shields.io and *.shields.io subdomains
- Logs debug message when skipping these URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)