### PR TITLE
Remove background fills from markdown diagrams

### DIFF
--- a/Mostlylucid/Markdown/ASPNET-PIPELINE-PART3-MIDDLEWARE.md
+++ b/Mostlylucid/Markdown/ASPNET-PIPELINE-PART3-MIDDLEWARE.md
@@ -433,8 +433,8 @@ graph TD
     E --> F[Routing/Endpoints]
     F --> G[Return 404]
 
-    style C fill:#ccffcc
-    style G fill:#ffcccc
+    style C stroke:#10b981,stroke-width:3px
+    style G stroke:#ef4444,stroke-width:3px
 ```
 
 ### Authentication Middleware

--- a/Mostlylucid/Markdown/ASPNET-PIPELINE-PART4-ROUTING-ENDPOINTS.md
+++ b/Mostlylucid/Markdown/ASPNET-PIPELINE-PART4-ROUTING-ENDPOINTS.md
@@ -69,9 +69,9 @@ graph LR
     I -->|Yes| J[Execute Endpoint]
     I -->|No| K[404 Not Found]
 
-    style B fill:#ffe1e1
-    style H fill:#e1ffe1
-    style J fill:#e1e1ff
+    style B stroke:#ef4444,stroke-width:3px
+    style H stroke:#10b981,stroke-width:3px
+    style J stroke:#6366f1,stroke-width:3px
 ```
 
 ### Phase 1: Route Matching (`UseRouting()`)

--- a/Mostlylucid/Markdown/ASPNET-PIPELINE-PART5-APPLICATION-MODELS.md
+++ b/Mostlylucid/Markdown/ASPNET-PIPELINE-PART5-APPLICATION-MODELS.md
@@ -183,8 +183,8 @@ graph TD
     Body --> Handler
     Services --> Handler
 
-    style Request fill:#ffe1e1
-    style Handler fill:#e1ffe1
+    style Request stroke:#ef4444,stroke-width:3px
+    style Handler stroke:#10b981,stroke-width:3px
 ```
 
 ### Results and Responses
@@ -910,8 +910,8 @@ graph TD
     N --> O[Response]
     D --> O
 
-    style H fill:#ffe1e1
-    style L fill:#e1ffe1
+    style H stroke:#ef4444,stroke-width:3px
+    style L stroke:#10b981,stroke-width:3px
 ```
 
 **Filter types:**
@@ -1170,9 +1170,9 @@ graph TB
         MVC3 --> MVC4
     end
 
-    style MA1 fill:#e1ffe1
-    style RP1 fill:#ffe1e1
-    style MVC1 fill:#e1e1ff
+    style MA1 stroke:#10b981,stroke-width:3px
+    style RP1 stroke:#ef4444,stroke-width:3px
+    style MVC1 stroke:#6366f1,stroke-width:3px
 ```
 
 | Feature | Minimal APIs | Razor Pages | MVC |

--- a/Mostlylucid/Markdown/enhancingmermaiddiagramswithpanzoomandexport.md
+++ b/Mostlylucid/Markdown/enhancingmermaiddiagramswithpanzoomandexport.md
@@ -671,11 +671,11 @@ graph TB
         Q -->|12 Languages| R[Translated Files]
     end 
 
-    style A fill:#4ade80
-    style G fill:#60a5fa
-    style J fill:#f59e0b
-    style K fill:#ec4899
-    style M fill:#8b5cf6
+    style A stroke:#22c55e,stroke-width:3px,color:#4ade80
+    style G stroke:#3b82f6,stroke-width:3px,color:#60a5fa
+    style J stroke:#f59e0b,stroke-width:3px,color:#f59e0b
+    style K stroke:#ec4899,stroke-width:3px,color:#ec4899
+    style M stroke:#8b5cf6,stroke-width:3px,color:#8b5cf6
 ```
 
 Try clicking the controls on the diagram above!

--- a/Mostlylucid/Markdown/mermaid-js-deep-dive.md
+++ b/Mostlylucid/Markdown/mermaid-js-deep-dive.md
@@ -76,10 +76,10 @@ graph TD
     G --> H[Inserted into DOM]
     H --> I[Your Enhancements Run]
 
-    style A fill:#10b981,stroke:#059669,color:#fff
-    style D fill:#3b82f6,stroke:#2563eb,color:#fff
-    style G fill:#8b5cf6,stroke:#7c3aed,color:#fff
-    style I fill:#f59e0b,stroke:#d97706,color:#fff
+    style A stroke:#059669,stroke-width:3px,color:#10b981
+    style D stroke:#2563eb,stroke-width:3px,color:#3b82f6
+    style G stroke:#7c3aed,stroke-width:3px,color:#8b5cf6
+    style I stroke:#d97706,stroke-width:3px,color:#f59e0b
 ```
 
 Let's break down each step.
@@ -537,9 +537,9 @@ graph TB
     M --> M3[Fullscreen]
     M --> M4[Export PNG/SVG]
 
-    style A fill:#10b981,stroke:#059669,color:#fff
-    style L fill:#3b82f6,stroke:#2563eb,color:#fff
-    style M fill:#8b5cf6,stroke:#7c3aed,color:#fff
+    style A stroke:#059669,stroke-width:3px,color:#10b981
+    style L stroke:#2563eb,stroke-width:3px,color:#3b82f6
+    style M stroke:#7c3aed,stroke-width:3px,color:#8b5cf6
 ```
 
 ## Usage

--- a/Mostlylucid/Markdown/modernising-frontend-build-pipeline.md
+++ b/Mostlylucid/Markdown/modernising-frontend-build-pipeline.md
@@ -574,9 +574,9 @@ graph TD
 
     Z --> AA[Browser]
 
-    style A fill:#e1f5ff
-    style Z fill:#fff4e1
-    style AA fill:#e8f5e9
+    style A stroke:#0ea5e9,stroke-width:3px
+    style Z stroke:#f59e0b,stroke-width:3px
+    style AA stroke:#10b981,stroke-width:3px
 ```
 
 It looks pretty complex but really that's what WebPack does, it handles most of this itself (in a complicated way that the likes of Vite don't need but.. )

--- a/Mostlylucid/Markdown/pagingtaghelper1.md
+++ b/Mostlylucid/Markdown/pagingtaghelper1.md
@@ -47,8 +47,8 @@ graph TD
     H --> I[Returns: Data + Token_B]
     I --> J[Page 3: Token_B]
 
-    style A fill:#e1f5ff
-    style E fill:#ffe1f5
+    style A stroke:#0ea5e9,stroke-width:3px
+    style E stroke:#ec4899,stroke-width:3px
 ```
 
 **Traditional Paging:**

--- a/Mostlylucid/Markdown/publishingmermaidenhancementsnpm.md
+++ b/Mostlylucid/Markdown/publishingmermaidenhancementsnpm.md
@@ -103,9 +103,9 @@ graph TD
     M --> M3[Fullscreen]
     M --> M4[Export PNG/SVG]
 
-    style A fill:#10b981,stroke:#059669,color:#fff
-    style L fill:#3b82f6,stroke:#2563eb,color:#fff
-    style M fill:#8b5cf6,stroke:#7c3aed,color:#fff
+    style A stroke:#059669,stroke-width:3px,color:#10b981
+    style L stroke:#2563eb,stroke-width:3px,color:#3b82f6
+    style M stroke:#7c3aed,stroke-width:3px,color:#8b5cf6
 ```
 
 # Core Implementation

--- a/Mostlylucid/Markdown/securechatdemo.md
+++ b/Mostlylucid/Markdown/securechatdemo.md
@@ -242,8 +242,8 @@ flowchart LR
     C --> D[Dead Code Injection<br/>Add junk functions]
     D --> E[Deployed Script<br/>~400 bytes minified]
 
-    style A fill:#e1f5ff
-    style E fill:#ffe1e1
+    style A stroke:#0ea5e9,stroke-width:3px
+    style E stroke:#ef4444,stroke-width:3px
 ```
 
 #### Source Code (Readable)

--- a/Mostlylucid/Markdown/semanticintelligence-part10.md
+++ b/Mostlylucid/Markdown/semanticintelligence-part10.md
@@ -228,14 +228,14 @@ graph TB
 
     Send --> |Message ID: msg_7x3f...<br/>Status: Queued| Success([✓ Workflow Complete<br/>Total: 18.7s])
 
-    style Fetch fill:#e3f2fd,stroke:#1976d2,stroke-width:2px
-    style Summarize fill:#e8f5e9,stroke:#388e3c,stroke-width:2px
-    style Translate fill:#fff3e0,stroke:#f57c00,stroke-width:2px
-    style Validate fill:#fce4ec,stroke:#c2185b,stroke-width:2px
-    style Retry fill:#f3e5f5,stroke:#7b1fa2,stroke-width:2px
-    style HTML fill:#e0f2f1,stroke:#00796b,stroke-width:2px
-    style Send fill:#e8eaf6,stroke:#3f51b5,stroke-width:2px
-    style Success fill:#c8e6c9,stroke:#2e7d32,stroke-width:3px
+    style Fetch stroke:#1976d2,stroke-width:3px,color:#1976d2
+    style Summarize stroke:#388e3c,stroke-width:3px,color:#388e3c
+    style Translate stroke:#f57c00,stroke-width:3px,color:#f57c00
+    style Validate stroke:#c2185b,stroke-width:3px,color:#c2185b
+    style Retry stroke:#7b1fa2,stroke-width:3px,color:#7b1fa2
+    style HTML stroke:#00796b,stroke-width:3px,color:#00796b
+    style Send stroke:#3f51b5,stroke-width:3px,color:#3f51b5
+    style Success stroke:#2e7d32,stroke-width:4px,color:#2e7d32
 ```
 
 ### What Actually Happened
@@ -737,12 +737,12 @@ graph TB
 
     Tool3 --> Final[ALL workflows benefit<br/>Zero code changes needed]
 
-    style Original fill:#e3f2fd,stroke:#1976d2,stroke-width:2px
-    style Tool1 fill:#e8f5e9,stroke:#388e3c,stroke-width:2px
-    style Tool2 fill:#fff3e0,stroke:#f57c00,stroke-width:2px
-    style Tool3 fill:#f3e5f5,stroke:#7b1fa2,stroke-width:2px
-    style Contribution fill:#e1f5fe,stroke:#0277bd,stroke-width:3px
-    style Final fill:#c8e6c9,stroke:#2e7d32,stroke-width:3px
+    style Original stroke:#1976d2,stroke-width:3px,color:#1976d2
+    style Tool1 stroke:#388e3c,stroke-width:3px,color:#388e3c
+    style Tool2 stroke:#f57c00,stroke-width:3px,color:#f57c00
+    style Tool3 stroke:#7b1fa2,stroke-width:3px,color:#7b1fa2
+    style Contribution stroke:#0277bd,stroke-width:4px,color:#0277bd
+    style Final stroke:#2e7d32,stroke-width:4px,color:#2e7d32
 ```
 
 **One workflow created a tool. That tool evolved. A smarter AI improved it. Every workflow benefits.**
@@ -901,15 +901,15 @@ graph TB
     V201 --> Current2[Active workflows<br/>using v2.0.1]
     V211 --> Current3[Active workflows<br/>using v2.1.1]
 
-    style V10 fill:#e8f5e9,stroke:#388e3c,stroke-width:2px
-    style V11 fill:#e8f5e9,stroke:#388e3c,stroke-width:2px
-    style V12 fill:#ffebee,stroke:#c62828,stroke-width:2px,stroke-dasharray: 5 5
-    style V121 fill:#e1f5fe,stroke:#0277bd,stroke-width:3px
-    style V20 fill:#ffebee,stroke:#c62828,stroke-width:2px,stroke-dasharray: 5 5
-    style V201 fill:#e1f5fe,stroke:#0277bd,stroke-width:3px
-    style V21 fill:#ffebee,stroke:#c62828,stroke-width:2px,stroke-dasharray: 5 5
-    style V211 fill:#e1f5fe,stroke:#0277bd,stroke-width:3px
-    style Current3 fill:#c8e6c9,stroke:#2e7d32,stroke-width:3px
+    style V10 stroke:#388e3c,stroke-width:3px,color:#388e3c
+    style V11 stroke:#388e3c,stroke-width:3px,color:#388e3c
+    style V12 stroke:#c62828,stroke-width:3px,stroke-dasharray: 5 5,color:#c62828
+    style V121 stroke:#0277bd,stroke-width:4px,color:#0277bd
+    style V20 stroke:#c62828,stroke-width:3px,stroke-dasharray: 5 5,color:#c62828
+    style V201 stroke:#0277bd,stroke-width:4px,color:#0277bd
+    style V21 stroke:#c62828,stroke-width:3px,stroke-dasharray: 5 5,color:#c62828
+    style V211 stroke:#0277bd,stroke-width:4px,color:#0277bd
+    style Current3 stroke:#2e7d32,stroke-width:4px,color:#2e7d32
 ```
 
 **The system:**

--- a/Mostlylucid/Markdown/semanticintelligence-part8.md
+++ b/Mostlylucid/Markdown/semanticintelligence-part8.md
@@ -1796,14 +1796,14 @@ graph TB
 
     T3 --> W2
 
-    style T1 fill:#ffcccc
-    style T2 fill:#ccffcc
-    style T3 fill:#ccccff
-    style W1 fill:#ffffcc
-    style W2 fill:#ffffcc
-    style W3 fill:#ffffcc
-    style U1 fill:#ffeecc
-    style U2 fill:#ffeecc
+    style T1 stroke:#ef4444,stroke-width:3px
+    style T2 stroke:#10b981,stroke-width:3px
+    style T3 stroke:#6366f1,stroke-width:3px
+    style W1 stroke:#eab308,stroke-width:3px
+    style W2 stroke:#eab308,stroke-width:3px
+    style W3 stroke:#eab308,stroke-width:3px
+    style U1 stroke:#f59e0b,stroke-width:3px
+    style U2 stroke:#f59e0b,stroke-width:3px
 ```
 
 **Genetic Inheritance:**

--- a/Mostlylucid/Markdown/signalr-demo-guide.md
+++ b/Mostlylucid/Markdown/signalr-demo-guide.md
@@ -430,10 +430,10 @@ graph LR
 
     D --> E
 
-    style B fill:#e1ffe1
-    style G fill:#e1f5ff
-    style H fill:#ffe1e1
-    style I fill:#fff4e1
+    style B stroke:#10b981,stroke-width:3px
+    style G stroke:#0ea5e9,stroke-width:3px
+    style H stroke:#ef4444,stroke-width:3px
+    style I stroke:#f59e0b,stroke-width:3px
 ```
 
 ## Troubleshooting Common Issues


### PR DESCRIPTION
Replace all background fill colors with stroke-based styling across 12 markdown files:
- Convert simple fills to stroke with 3px width
- For diagrams with existing strokes, remove fill and keep stroke + color
- Use appropriate color values to enhance diagram visibility
- Maintain visual distinction with varied stroke colors

Files updated:
- ASPNET-PIPELINE-PART3-MIDDLEWARE.md
- ASPNET-PIPELINE-PART4-ROUTING-ENDPOINTS.md
- ASPNET-PIPELINE-PART5-APPLICATION-MODELS.md (3 diagrams)
- enhancingmermaiddiagramswithpanzoomandexport.md
- mermaid-js-deep-dive.md (2 diagrams)
- modernising-frontend-build-pipeline.md
- pagingtaghelper1.md
- publishingmermaidenhancementsnpm.md
- securechatdemo.md
- semanticintelligence-part10.md (3 diagrams)
- semanticintelligence-part8.md
- signalr-demo-guide.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)