### PR TITLE
Add 404 suggester for semantic search tool

### DIFF
--- a/Mostlylucid.DbContext/EntityFramework/MostlylucidDBContext.cs
+++ b/Mostlylucid.DbContext/EntityFramework/MostlylucidDBContext.cs
@@ -26,6 +26,10 @@ public class MostlylucidDbContext : Microsoft.EntityFrameworkCore.DbContext, IMo
 
     public DbSet<DownloadedImageEntity> DownloadedImages { get; set; }
 
+    public DbSet<SlugRedirectEntity> SlugRedirects { get; set; }
+
+    public DbSet<SlugSuggestionClickEntity> SlugSuggestionClicks { get; set; }
+
     protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
     {
         configurationBuilder
@@ -190,6 +194,33 @@ public class MostlylucidDbContext : Microsoft.EntityFrameworkCore.DbContext, IMo
                     b => b.HasOne<BlogPostEntity>().WithMany().HasForeignKey("BlogPostId"),
                     c => c.HasOne<CategoryEntity>().WithMany().HasForeignKey("CategoryId")
                 );
+        });
+
+        modelBuilder.Entity<SlugRedirectEntity>(entity =>
+        {
+            entity.ToTable("slug_redirects");
+            entity.HasKey(x => x.Id);
+
+            // Unique index on (FromSlug, ToSlug, Language) - each redirect mapping should be unique
+            entity.HasIndex(x => new { x.FromSlug, x.ToSlug, x.Language }).IsUnique();
+
+            // Index for fast lookup of redirects from a given slug
+            entity.HasIndex(x => new { x.FromSlug, x.Language, x.AutoRedirect });
+
+            entity.Property(x => x.CreatedAt).HasDefaultValueSql("CURRENT_TIMESTAMP");
+            entity.Property(x => x.UpdatedAt).HasDefaultValueSql("CURRENT_TIMESTAMP");
+        });
+
+        modelBuilder.Entity<SlugSuggestionClickEntity>(entity =>
+        {
+            entity.ToTable("slug_suggestion_clicks");
+            entity.HasKey(x => x.Id);
+
+            // Index for analytics queries
+            entity.HasIndex(x => new { x.RequestedSlug, x.ClickedSlug, x.Language });
+            entity.HasIndex(x => x.ClickedAt);
+
+            entity.Property(x => x.ClickedAt).HasDefaultValueSql("CURRENT_TIMESTAMP");
         });
     }
 }

--- a/Mostlylucid.Services/Blog/ISlugSuggestionService.cs
+++ b/Mostlylucid.Services/Blog/ISlugSuggestionService.cs
@@ -1,0 +1,73 @@
+using Mostlylucid.Shared.Models.Blog;
+
+namespace Mostlylucid.Services.Blog;
+
+/// <summary>
+/// Service for suggesting alternative blog post slugs when a 404 occurs
+/// with machine learning capabilities
+/// </summary>
+public interface ISlugSuggestionService
+{
+    /// <summary>
+    /// Get suggested blog posts based on a malformed or not-found slug
+    /// This method incorporates learned weights from previous user clicks
+    /// </summary>
+    /// <param name="requestedSlug">The slug that was not found</param>
+    /// <param name="language">The requested language (defaults to "en")</param>
+    /// <param name="maxSuggestions">Maximum number of suggestions to return</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>List of suggested blog posts</returns>
+    Task<List<PostListModel>> GetSlugSuggestionsAsync(
+        string requestedSlug,
+        string language = "en",
+        int maxSuggestions = 5,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Record that a user clicked on a suggested slug from a 404 page
+    /// This updates the learned weights for future suggestions
+    /// </summary>
+    /// <param name="requestedSlug">The original slug that caused the 404</param>
+    /// <param name="clickedSlug">The suggested slug that was clicked</param>
+    /// <param name="language">The language of the blog post</param>
+    /// <param name="suggestionPosition">Position of the clicked suggestion in the list (0-based)</param>
+    /// <param name="originalScore">The original similarity score from the algorithm</param>
+    /// <param name="userIp">User's IP address (optional, for analytics)</param>
+    /// <param name="userAgent">User agent string (optional)</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    Task RecordSuggestionClickAsync(
+        string requestedSlug,
+        string clickedSlug,
+        string language,
+        int suggestionPosition,
+        double originalScore,
+        string? userIp = null,
+        string? userAgent = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Record that suggestions were shown but not clicked
+    /// This helps calculate confidence scores
+    /// </summary>
+    /// <param name="requestedSlug">The slug that caused the 404</param>
+    /// <param name="shownSlugs">List of slugs that were shown as suggestions</param>
+    /// <param name="language">The language of the blog post</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    Task RecordSuggestionsShownAsync(
+        string requestedSlug,
+        List<string> shownSlugs,
+        string language,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Check if a slug should automatically redirect (without showing 404)
+    /// </summary>
+    /// <param name="requestedSlug">The slug to check</param>
+    /// <param name="language">The language</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The target slug to redirect to, or null if no auto-redirect</returns>
+    Task<string?> GetAutoRedirectSlugAsync(
+        string requestedSlug,
+        string language,
+        CancellationToken cancellationToken = default);
+}

--- a/Mostlylucid.Services/Blog/SlugSuggestionService.cs
+++ b/Mostlylucid.Services/Blog/SlugSuggestionService.cs
@@ -1,0 +1,407 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Mostlylucid.DbContext.Postgre;
+using Mostlylucid.Shared.Entities;
+using Mostlylucid.Shared.Models.Blog;
+
+namespace Mostlylucid.Services.Blog;
+
+/// <summary>
+/// Service for suggesting alternative blog post slugs using fuzzy string matching
+/// with machine learning capabilities
+/// </summary>
+public class SlugSuggestionService : ISlugSuggestionService
+{
+    private readonly MostlylucidDbContext _context;
+    private readonly ILogger<SlugSuggestionService> _logger;
+    private const int MaxLevenshteinDistance = 5; // Maximum edit distance for suggestions
+    private const double MinSimilarityThreshold = 0.4; // Minimum similarity score (0-1)
+    private const double LearnedWeightBoost = 0.3; // Boost for learned redirects
+
+    public SlugSuggestionService(
+        MostlylucidDbContext context,
+        ILogger<SlugSuggestionService> logger)
+    {
+        _context = context;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<List<PostListModel>> GetSlugSuggestionsAsync(
+        string requestedSlug,
+        string language = "en",
+        int maxSuggestions = 5,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(requestedSlug))
+        {
+            return new List<PostListModel>();
+        }
+
+        // Normalize the requested slug
+        var normalizedSlug = NormalizeSlug(requestedSlug);
+
+        _logger.LogInformation("Finding suggestions for slug: {RequestedSlug} (normalized: {NormalizedSlug})",
+            requestedSlug, normalizedSlug);
+
+        // Get learned redirects for this slug
+        var learnedRedirects = await _context.SlugRedirects
+            .AsNoTracking()
+            .Where(r => r.FromSlug == normalizedSlug && r.Language == language)
+            .ToDictionaryAsync(r => r.ToSlug, r => r, cancellationToken);
+
+        // Get all blog posts with their slugs for the specified language
+        var allPosts = await _context.BlogPosts
+            .AsNoTracking()
+            .Where(p => p.LanguageEntity.Name == language && !p.IsHidden)
+            .Select(p => new
+            {
+                p.Id,
+                p.Slug,
+                p.Title,
+                p.PublishedDate,
+                p.Categories,
+                Language = p.LanguageEntity.Name
+            })
+            .ToListAsync(cancellationToken);
+
+        if (!allPosts.Any())
+        {
+            _logger.LogWarning("No blog posts found for language: {Language}", language);
+            return new List<PostListModel>();
+        }
+
+        // Calculate similarity scores for each post, boosting learned redirects
+        var scoredPosts = allPosts
+            .Select(post =>
+            {
+                var baseScore = CalculateSimilarity(normalizedSlug, post.Slug);
+
+                // Boost score if this is a learned redirect
+                if (learnedRedirects.TryGetValue(post.Slug, out var redirect))
+                {
+                    // Add boost based on confidence score
+                    baseScore += LearnedWeightBoost * redirect.ConfidenceScore;
+                    baseScore = Math.Min(1.0, baseScore); // Cap at 1.0
+
+                    _logger.LogDebug("Boosting {Slug} from {BaseScore} by {Boost} (weight: {Weight}, confidence: {Confidence})",
+                        post.Slug, baseScore - LearnedWeightBoost * redirect.ConfidenceScore,
+                        LearnedWeightBoost * redirect.ConfidenceScore, redirect.Weight, redirect.ConfidenceScore);
+                }
+
+                return new
+                {
+                    Post = post,
+                    Score = baseScore
+                };
+            })
+            .Where(x => x.Score >= MinSimilarityThreshold)
+            .OrderByDescending(x => x.Score)
+            .Take(maxSuggestions)
+            .ToList();
+
+        if (!scoredPosts.Any())
+        {
+            _logger.LogInformation("No similar slugs found for: {RequestedSlug}", requestedSlug);
+
+            // Fall back to checking if any slug contains the requested slug as substring
+            scoredPosts = allPosts
+                .Where(p => p.Slug.Contains(normalizedSlug, StringComparison.OrdinalIgnoreCase) ||
+                           normalizedSlug.Contains(p.Slug, StringComparison.OrdinalIgnoreCase))
+                .Select(post => new
+                {
+                    Post = post,
+                    Score = 0.5 // Give these a moderate score
+                })
+                .Take(maxSuggestions)
+                .ToList();
+        }
+
+        _logger.LogInformation("Found {Count} suggestions for slug: {RequestedSlug}",
+            scoredPosts.Count, requestedSlug);
+
+        // Map to PostListModel
+        var suggestions = scoredPosts.Select(x => new PostListModel
+        {
+            Id = x.Post.Id,
+            Slug = x.Post.Slug,
+            Title = x.Post.Title,
+            PublishedDate = x.Post.PublishedDate,
+            Categories = x.Post.Categories.Select(c => c.Name).ToList(),
+            Language = x.Post.Language
+        }).ToList();
+
+        return suggestions;
+    }
+
+    /// <inheritdoc />
+    public async Task RecordSuggestionClickAsync(
+        string requestedSlug,
+        string clickedSlug,
+        string language,
+        int suggestionPosition,
+        double originalScore,
+        string? userIp = null,
+        string? userAgent = null,
+        CancellationToken cancellationToken = default)
+    {
+        var normalizedRequestedSlug = NormalizeSlug(requestedSlug);
+        var normalizedClickedSlug = NormalizeSlug(clickedSlug);
+
+        _logger.LogInformation("Recording click: {RequestedSlug} -> {ClickedSlug} (position: {Position})",
+            normalizedRequestedSlug, normalizedClickedSlug, suggestionPosition);
+
+        // Record the click event
+        var clickEntity = new SlugSuggestionClickEntity
+        {
+            RequestedSlug = normalizedRequestedSlug,
+            ClickedSlug = normalizedClickedSlug,
+            Language = language,
+            SuggestionPosition = suggestionPosition,
+            OriginalSimilarityScore = originalScore,
+            UserIp = userIp,
+            UserAgent = userAgent,
+            ClickedAt = DateTimeOffset.UtcNow
+        };
+
+        _context.SlugSuggestionClicks.Add(clickEntity);
+
+        // Update or create the redirect mapping
+        var redirect = await _context.SlugRedirects
+            .FirstOrDefaultAsync(r =>
+                r.FromSlug == normalizedRequestedSlug &&
+                r.ToSlug == normalizedClickedSlug &&
+                r.Language == language,
+                cancellationToken);
+
+        if (redirect == null)
+        {
+            redirect = new SlugRedirectEntity
+            {
+                FromSlug = normalizedRequestedSlug,
+                ToSlug = normalizedClickedSlug,
+                Language = language,
+                Weight = 1,
+                ShownCount = 0,
+                CreatedAt = DateTimeOffset.UtcNow
+            };
+            redirect.UpdateConfidenceScore();
+            _context.SlugRedirects.Add(redirect);
+        }
+        else
+        {
+            redirect.Weight++;
+            redirect.LastClickedAt = DateTimeOffset.UtcNow;
+            redirect.UpdatedAt = DateTimeOffset.UtcNow;
+            redirect.UpdateConfidenceScore();
+        }
+
+        await _context.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "Updated redirect mapping: {From} -> {To} (weight: {Weight}, confidence: {Confidence:P}, auto: {Auto})",
+            normalizedRequestedSlug, normalizedClickedSlug, redirect.Weight,
+            redirect.ConfidenceScore, redirect.AutoRedirect);
+    }
+
+    /// <inheritdoc />
+    public async Task RecordSuggestionsShownAsync(
+        string requestedSlug,
+        List<string> shownSlugs,
+        string language,
+        CancellationToken cancellationToken = default)
+    {
+        var normalizedRequestedSlug = NormalizeSlug(requestedSlug);
+
+        foreach (var shownSlug in shownSlugs)
+        {
+            var normalizedShownSlug = NormalizeSlug(shownSlug);
+
+            var redirect = await _context.SlugRedirects
+                .FirstOrDefaultAsync(r =>
+                    r.FromSlug == normalizedRequestedSlug &&
+                    r.ToSlug == normalizedShownSlug &&
+                    r.Language == language,
+                    cancellationToken);
+
+            if (redirect != null)
+            {
+                redirect.ShownCount++;
+                redirect.UpdatedAt = DateTimeOffset.UtcNow;
+                redirect.UpdateConfidenceScore();
+            }
+        }
+
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<string?> GetAutoRedirectSlugAsync(
+        string requestedSlug,
+        string language,
+        CancellationToken cancellationToken = default)
+    {
+        var normalizedSlug = NormalizeSlug(requestedSlug);
+
+        var redirect = await _context.SlugRedirects
+            .AsNoTracking()
+            .Where(r =>
+                r.FromSlug == normalizedSlug &&
+                r.Language == language &&
+                r.AutoRedirect)
+            .OrderByDescending(r => r.ConfidenceScore)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (redirect != null)
+        {
+            _logger.LogInformation(
+                "Auto-redirect found: {From} -> {To} (weight: {Weight}, confidence: {Confidence:P})",
+                normalizedSlug, redirect.ToSlug, redirect.Weight, redirect.ConfidenceScore);
+        }
+
+        return redirect?.ToSlug;
+    }
+
+    /// <summary>
+    /// Calculate similarity between two strings using a combination of Levenshtein distance
+    /// and longest common subsequence
+    /// </summary>
+    private double CalculateSimilarity(string source, string target)
+    {
+        if (string.Equals(source, target, StringComparison.OrdinalIgnoreCase))
+        {
+            return 1.0;
+        }
+
+        source = source.ToLowerInvariant();
+        target = target.ToLowerInvariant();
+
+        // Calculate Levenshtein distance
+        var distance = CalculateLevenshteinDistance(source, target);
+        var maxLength = Math.Max(source.Length, target.Length);
+
+        if (maxLength == 0)
+        {
+            return 1.0;
+        }
+
+        // Convert distance to similarity score (0-1, where 1 is identical)
+        var levenshteinSimilarity = 1.0 - (double)distance / maxLength;
+
+        // Calculate substring bonus (if one is contained in the other)
+        var substringBonus = 0.0;
+        if (source.Contains(target) || target.Contains(source))
+        {
+            substringBonus = 0.2;
+        }
+
+        // Calculate prefix bonus (common starting characters)
+        var prefixLength = GetCommonPrefixLength(source, target);
+        var prefixBonus = (double)prefixLength / Math.Min(source.Length, target.Length) * 0.1;
+
+        // Combine scores
+        var finalScore = Math.Min(1.0, levenshteinSimilarity + substringBonus + prefixBonus);
+
+        return finalScore;
+    }
+
+    /// <summary>
+    /// Calculate Levenshtein distance between two strings (edit distance)
+    /// </summary>
+    private int CalculateLevenshteinDistance(string source, string target)
+    {
+        if (string.IsNullOrEmpty(source))
+        {
+            return target?.Length ?? 0;
+        }
+
+        if (string.IsNullOrEmpty(target))
+        {
+            return source.Length;
+        }
+
+        var sourceLength = source.Length;
+        var targetLength = target.Length;
+
+        // Create a matrix to store distances
+        var matrix = new int[sourceLength + 1, targetLength + 1];
+
+        // Initialize first column and row
+        for (var i = 0; i <= sourceLength; i++)
+        {
+            matrix[i, 0] = i;
+        }
+
+        for (var j = 0; j <= targetLength; j++)
+        {
+            matrix[0, j] = j;
+        }
+
+        // Calculate distances
+        for (var i = 1; i <= sourceLength; i++)
+        {
+            for (var j = 1; j <= targetLength; j++)
+            {
+                var cost = source[i - 1] == target[j - 1] ? 0 : 1;
+
+                matrix[i, j] = Math.Min(
+                    Math.Min(
+                        matrix[i - 1, j] + 1,      // Deletion
+                        matrix[i, j - 1] + 1),      // Insertion
+                    matrix[i - 1, j - 1] + cost);   // Substitution
+            }
+        }
+
+        return matrix[sourceLength, targetLength];
+    }
+
+    /// <summary>
+    /// Get the length of the common prefix between two strings
+    /// </summary>
+    private int GetCommonPrefixLength(string source, string target)
+    {
+        var minLength = Math.Min(source.Length, target.Length);
+        var prefixLength = 0;
+
+        for (var i = 0; i < minLength; i++)
+        {
+            if (source[i] == target[i])
+            {
+                prefixLength++;
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        return prefixLength;
+    }
+
+    /// <summary>
+    /// Normalize a slug for comparison
+    /// </summary>
+    private string NormalizeSlug(string slug)
+    {
+        if (string.IsNullOrWhiteSpace(slug))
+        {
+            return string.Empty;
+        }
+
+        // Remove .md extension if present
+        if (slug.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
+        {
+            slug = slug[..^3];
+        }
+
+        // Convert underscores and spaces to hyphens, and lowercase
+        slug = slug.Replace('_', '-')
+                  .Replace(' ', '-')
+                  .ToLowerInvariant();
+
+        // Remove any trailing slashes
+        slug = slug.TrimEnd('/');
+
+        return slug;
+    }
+}

--- a/Mostlylucid.Shared/Entities/SlugRedirectEntity.cs
+++ b/Mostlylucid.Shared/Entities/SlugRedirectEntity.cs
@@ -1,0 +1,103 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Mostlylucid.Shared.Entities;
+
+/// <summary>
+/// Entity for tracking learned slug redirects from 404 errors
+/// </summary>
+[Table("slug_redirects", Schema = "mostlylucid")]
+public class SlugRedirectEntity
+{
+    [Key]
+    [Column("id")]
+    public int Id { get; set; }
+
+    /// <summary>
+    /// The incorrect slug that was requested (caused 404)
+    /// </summary>
+    [Required]
+    [Column("from_slug")]
+    [MaxLength(500)]
+    public string FromSlug { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The correct slug that users clicked on
+    /// </summary>
+    [Required]
+    [Column("to_slug")]
+    [MaxLength(500)]
+    public string ToSlug { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Language of the blog post
+    /// </summary>
+    [Required]
+    [Column("language")]
+    [MaxLength(10)]
+    public string Language { get; set; } = "en";
+
+    /// <summary>
+    /// Weight/score indicating how many times this redirect was clicked
+    /// Higher weight = more confidence in this redirect
+    /// </summary>
+    [Column("weight")]
+    public int Weight { get; set; } = 0;
+
+    /// <summary>
+    /// Number of times this suggestion was shown but not clicked
+    /// </summary>
+    [Column("shown_count")]
+    public int ShownCount { get; set; } = 0;
+
+    /// <summary>
+    /// Confidence score (Weight / (Weight + ShownCount))
+    /// </summary>
+    [Column("confidence_score")]
+    public double ConfidenceScore { get; set; } = 0.0;
+
+    /// <summary>
+    /// Whether this redirect should automatically redirect (301) without showing 404
+    /// </summary>
+    [Column("auto_redirect")]
+    public bool AutoRedirect { get; set; } = false;
+
+    /// <summary>
+    /// Threshold for auto-redirect (default 5 clicks with >70% confidence)
+    /// </summary>
+    public const int AutoRedirectWeightThreshold = 5;
+    public const double AutoRedirectConfidenceThreshold = 0.7;
+
+    /// <summary>
+    /// When this redirect was first created
+    /// </summary>
+    [Column("created_at")]
+    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+
+    /// <summary>
+    /// When this redirect was last updated
+    /// </summary>
+    [Column("updated_at")]
+    public DateTimeOffset UpdatedAt { get; set; } = DateTimeOffset.UtcNow;
+
+    /// <summary>
+    /// When the last click occurred
+    /// </summary>
+    [Column("last_clicked_at")]
+    public DateTimeOffset? LastClickedAt { get; set; }
+
+    /// <summary>
+    /// Calculate and update the confidence score
+    /// </summary>
+    public void UpdateConfidenceScore()
+    {
+        var total = Weight + ShownCount;
+        ConfidenceScore = total > 0 ? (double)Weight / total : 0.0;
+
+        // Automatically enable redirect if thresholds are met
+        if (Weight >= AutoRedirectWeightThreshold && ConfidenceScore >= AutoRedirectConfidenceThreshold)
+        {
+            AutoRedirect = true;
+        }
+    }
+}

--- a/Mostlylucid.Shared/Entities/SlugSuggestionClickEntity.cs
+++ b/Mostlylucid.Shared/Entities/SlugSuggestionClickEntity.cs
@@ -1,0 +1,72 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Mostlylucid.Shared.Entities;
+
+/// <summary>
+/// Entity for tracking individual clicks on slug suggestions from 404 pages
+/// Used for analytics and debugging the learning system
+/// </summary>
+[Table("slug_suggestion_clicks", Schema = "mostlylucid")]
+public class SlugSuggestionClickEntity
+{
+    [Key]
+    [Column("id")]
+    public int Id { get; set; }
+
+    /// <summary>
+    /// The incorrect slug that caused the 404
+    /// </summary>
+    [Required]
+    [Column("requested_slug")]
+    [MaxLength(500)]
+    public string RequestedSlug { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The suggested slug that was clicked
+    /// </summary>
+    [Required]
+    [Column("clicked_slug")]
+    [MaxLength(500)]
+    public string ClickedSlug { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Language of the blog post
+    /// </summary>
+    [Required]
+    [Column("language")]
+    [MaxLength(10)]
+    public string Language { get; set; } = "en";
+
+    /// <summary>
+    /// Position of the clicked suggestion in the list (0-based)
+    /// </summary>
+    [Column("suggestion_position")]
+    public int SuggestionPosition { get; set; }
+
+    /// <summary>
+    /// The original similarity score from the suggestion algorithm
+    /// </summary>
+    [Column("original_similarity_score")]
+    public double OriginalSimilarityScore { get; set; }
+
+    /// <summary>
+    /// User's IP address (for analytics, anonymized)
+    /// </summary>
+    [Column("user_ip")]
+    [MaxLength(50)]
+    public string? UserIp { get; set; }
+
+    /// <summary>
+    /// User agent string
+    /// </summary>
+    [Column("user_agent")]
+    [MaxLength(500)]
+    public string? UserAgent { get; set; }
+
+    /// <summary>
+    /// When this click occurred
+    /// </summary>
+    [Column("clicked_at")]
+    public DateTimeOffset ClickedAt { get; set; } = DateTimeOffset.UtcNow;
+}

--- a/Mostlylucid/Blog/BlogSetup.cs
+++ b/Mostlylucid/Blog/BlogSetup.cs
@@ -48,6 +48,7 @@ public static class BlogSetup
                 services.AddScoped<CommentViewService>();
                 services.AddSingleton<BlogUpdater>();
                 services.AddScoped<IBlogService, BlogService>();
+                services.AddScoped<ISlugSuggestionService, SlugSuggestionService>();
                 services.AddScoped<BlogValidationService>();
                 services.AddHostedService<MarkdownDirectoryWatcherService>();
                 services.AddHostedService<BlogReconciliationService>();

--- a/Mostlylucid/Controllers/ErrorController.cs
+++ b/Mostlylucid/Controllers/ErrorController.cs
@@ -1,14 +1,19 @@
 ﻿using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
+using Mostlylucid.Models.Error;
 using Mostlylucid.Services;
+using Mostlylucid.Services.Blog;
 
 namespace Mostlylucid.Controllers;
 
-public class ErrorController(BaseControllerService baseControllerService, ILogger<ErrorController> logger) : BaseController(baseControllerService, logger)
+public class ErrorController(
+    BaseControllerService baseControllerService,
+    ILogger<ErrorController> logger,
+    ISlugSuggestionService? slugSuggestionService = null) : BaseController(baseControllerService, logger)
 {
     [Route("/error/{statusCode}")]
     [HttpGet]
-    public IActionResult HandleError(int statusCode)
+    public async Task<IActionResult> HandleError(int statusCode, CancellationToken cancellationToken = default)
     {
         // Retrieve the original request information
         var statusCodeReExecuteFeature = HttpContext.Features.Get<IStatusCodeReExecuteFeature>();
@@ -28,11 +33,66 @@ public class ErrorController(BaseControllerService baseControllerService, ILogge
         switch (statusCode)
         {
             case 404:
-                return View("NotFound");
+                var model = await CreateNotFoundModel(statusCodeReExecuteFeature, cancellationToken);
+                return View("NotFound", model);
             case 500:
                 return View("ServerError");
             default:
                 return View("Error");
         }
+    }
+
+    private async Task<NotFoundModel> CreateNotFoundModel(
+        IStatusCodeReExecuteFeature? statusCodeReExecuteFeature,
+        CancellationToken cancellationToken)
+    {
+        var model = new NotFoundModel
+        {
+            OriginalPath = statusCodeReExecuteFeature?.OriginalPath ?? string.Empty,
+            Suggestions = new List<Mostlylucid.Shared.Models.Blog.PostListModel>()
+        };
+
+        if (slugSuggestionService == null || string.IsNullOrWhiteSpace(model.OriginalPath))
+        {
+            return model;
+        }
+
+        try
+        {
+            // Extract slug from path (e.g., /blog/my-post-slug or /blog/en/my-post-slug)
+            var pathSegments = model.OriginalPath.TrimStart('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
+
+            string? slug = null;
+            var language = "en"; // Default language
+
+            // Pattern: /blog/{slug} or /blog/{language}/{slug}
+            if (pathSegments.Length >= 2 && pathSegments[0].Equals("blog", StringComparison.OrdinalIgnoreCase))
+            {
+                if (pathSegments.Length == 2)
+                {
+                    // /blog/{slug}
+                    slug = pathSegments[1];
+                }
+                else if (pathSegments.Length >= 3)
+                {
+                    // /blog/{language}/{slug}
+                    language = pathSegments[1];
+                    slug = pathSegments[2];
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(slug))
+            {
+                logger.LogInformation("Searching for suggestions for slug: {Slug} in language: {Language}", slug, language);
+                model.Suggestions = await slugSuggestionService.GetSlugSuggestionsAsync(slug, language, 5, cancellationToken);
+                logger.LogInformation("Found {Count} suggestions for slug: {Slug}", model.Suggestions.Count, slug);
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error generating slug suggestions for path: {Path}", model.OriginalPath);
+        }
+
+        return model;
     }
 }

--- a/Mostlylucid/Controllers/SlugSuggestionController.cs
+++ b/Mostlylucid/Controllers/SlugSuggestionController.cs
@@ -1,0 +1,80 @@
+using Microsoft.AspNetCore.Mvc;
+using Mostlylucid.Services;
+using Mostlylucid.Services.Blog;
+
+namespace Mostlylucid.Controllers;
+
+/// <summary>
+/// API Controller for slug suggestion and redirect learning system
+/// </summary>
+[Route("api/[controller]")]
+[ApiController]
+public class SlugSuggestionController : BaseController
+{
+    private readonly ISlugSuggestionService? _slugSuggestionService;
+
+    public SlugSuggestionController(
+        BaseControllerService baseControllerService,
+        ILogger<SlugSuggestionController> logger,
+        ISlugSuggestionService? slugSuggestionService = null)
+        : base(baseControllerService, logger)
+    {
+        _slugSuggestionService = slugSuggestionService;
+    }
+
+    /// <summary>
+    /// Track when a user clicks on a suggestion from the 404 page
+    /// </summary>
+    [HttpPost("track-click")]
+    public async Task<IActionResult> TrackClick(
+        [FromBody] TrackClickRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        if (_slugSuggestionService == null)
+        {
+            return Ok(new { success = false, message = "Slug suggestion service not available" });
+        }
+
+        if (string.IsNullOrWhiteSpace(request.RequestedSlug) ||
+            string.IsNullOrWhiteSpace(request.ClickedSlug))
+        {
+            return BadRequest(new { success = false, message = "Invalid request" });
+        }
+
+        try
+        {
+            // Get user info
+            var userIp = HttpContext.Connection.RemoteIpAddress?.ToString();
+            var userAgent = HttpContext.Request.Headers["User-Agent"].ToString();
+
+            await _slugSuggestionService.RecordSuggestionClickAsync(
+                request.RequestedSlug,
+                request.ClickedSlug,
+                request.Language ?? "en",
+                request.SuggestionPosition,
+                request.OriginalScore,
+                userIp,
+                userAgent,
+                cancellationToken);
+
+            return Ok(new { success = true });
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error tracking suggestion click");
+            return Ok(new { success = false, message = "Error tracking click" });
+        }
+    }
+}
+
+/// <summary>
+/// Request model for tracking suggestion clicks
+/// </summary>
+public class TrackClickRequest
+{
+    public string RequestedSlug { get; set; } = string.Empty;
+    public string ClickedSlug { get; set; } = string.Empty;
+    public string? Language { get; set; }
+    public int SuggestionPosition { get; set; }
+    public double OriginalScore { get; set; }
+}

--- a/Mostlylucid/Middleware/SlugRedirectMiddleware.cs
+++ b/Mostlylucid/Middleware/SlugRedirectMiddleware.cs
@@ -1,0 +1,104 @@
+using Mostlylucid.Services.Blog;
+
+namespace Mostlylucid.Middleware;
+
+/// <summary>
+/// Middleware to handle automatic redirects for learned slug mappings
+/// This runs before the 404 handler and provides 301 Permanent Redirects
+/// </summary>
+public class SlugRedirectMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ILogger<SlugRedirectMiddleware> _logger;
+
+    public SlugRedirectMiddleware(RequestDelegate next, ILogger<SlugRedirectMiddleware> logger)
+    {
+        _next = next;
+        _logger = logger;
+    }
+
+    public async Task InvokeAsync(HttpContext context, ISlugSuggestionService? slugSuggestionService)
+    {
+        // Only process blog post requests
+        if (context.Request.Path.StartsWithSegments("/blog", StringComparison.OrdinalIgnoreCase))
+        {
+            // Only check if service is available
+            if (slugSuggestionService != null)
+            {
+                try
+                {
+                    // Extract slug and language from path
+                    var pathSegments = context.Request.Path.Value?
+                        .TrimStart('/')
+                        .Split('/', StringSplitOptions.RemoveEmptyEntries);
+
+                    if (pathSegments != null && pathSegments.Length >= 2 &&
+                        pathSegments[0].Equals("blog", StringComparison.OrdinalIgnoreCase))
+                    {
+                        string slug;
+                        var language = "en"; // Default language
+
+                        if (pathSegments.Length == 2)
+                        {
+                            // /blog/{slug}
+                            slug = pathSegments[1];
+                        }
+                        else if (pathSegments.Length >= 3)
+                        {
+                            // /blog/{language}/{slug}
+                            language = pathSegments[1];
+                            slug = pathSegments[2];
+                        }
+                        else
+                        {
+                            // Continue to next middleware
+                            await _next(context);
+                            return;
+                        }
+
+                        // Check if there's an auto-redirect for this slug
+                        var targetSlug = await slugSuggestionService.GetAutoRedirectSlugAsync(
+                            slug,
+                            language,
+                            context.RequestAborted);
+
+                        if (!string.IsNullOrWhiteSpace(targetSlug))
+                        {
+                            // Build the redirect URL
+                            var redirectUrl = language == "en"
+                                ? $"/blog/{targetSlug}"
+                                : $"/blog/{language}/{targetSlug}";
+
+                            _logger.LogInformation(
+                                "Auto-redirecting {OriginalPath} to {RedirectUrl}",
+                                context.Request.Path, redirectUrl);
+
+                            // 301 Permanent Redirect
+                            context.Response.Redirect(redirectUrl, permanent: true);
+                            return;
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    // Log error but don't break the request
+                    _logger.LogError(ex, "Error in slug redirect middleware");
+                }
+            }
+        }
+
+        // Continue to next middleware
+        await _next(context);
+    }
+}
+
+/// <summary>
+/// Extension methods for registering the slug redirect middleware
+/// </summary>
+public static class SlugRedirectMiddlewareExtensions
+{
+    public static IApplicationBuilder UseSlugRedirect(this IApplicationBuilder builder)
+    {
+        return builder.UseMiddleware<SlugRedirectMiddleware>();
+    }
+}

--- a/Mostlylucid/Models/Error/NotFoundModel.cs
+++ b/Mostlylucid/Models/Error/NotFoundModel.cs
@@ -1,6 +1,9 @@
-﻿namespace Mostlylucid.Models.Error;
+﻿using Mostlylucid.Shared.Models.Blog;
+
+namespace Mostlylucid.Models.Error;
 
 public class NotFoundModel
 {
-    public string OriginalPath { get; set; }
+    public string OriginalPath { get; set; } = string.Empty;
+    public List<PostListModel> Suggestions { get; set; } = new();
 }

--- a/Mostlylucid/Program.cs
+++ b/Mostlylucid/Program.cs
@@ -1,6 +1,7 @@
 using System.Security.Cryptography.X509Certificates;
 using Mostlylucid.Blog.WatcherService;
 using Mostlylucid.DbContext.EntityFramework;
+using Mostlylucid.Middleware;
 using Mostlylucid.Services;
 using Mostlylucid.Services.Images;
 using OpenTelemetry.Metrics;
@@ -222,6 +223,11 @@ try
             }
         }
     });
+
+    // Add slug redirect middleware before status code pages
+    // This allows automatic redirects for learned slug mappings
+    app.UseSlugRedirect();
+
     app.UseStatusCodePagesWithReExecute("/error/{0}");
 
     app.UseRouting();

--- a/Mostlylucid/Views/Error/NotFound.cshtml
+++ b/Mostlylucid/Views/Error/NotFound.cshtml
@@ -1,8 +1,70 @@
-﻿
+﻿@model Mostlylucid.Models.Error.NotFoundModel
 
-<h1>404 - Page not found</h1>
+<div class="container mx-auto px-4 py-8">
+    <h1 class="text-4xl font-bold mb-4">404 - Page not found</h1>
 
-<p>Sorry that Url doesn't look valid</p>
+    <p class="text-lg mb-6">Sorry, that URL doesn't look valid.</p>
+
+    @if (!string.IsNullOrWhiteSpace(Model?.OriginalPath))
+    {
+        <p class="text-sm text-gray-600 dark:text-gray-400 mb-6">
+            Requested path: <code class="bg-gray-100 dark:bg-gray-800 px-2 py-1 rounded">@Model.OriginalPath</code>
+        </p>
+    }
+
+    @if (Model?.Suggestions?.Any() == true)
+    {
+        <div class="mt-8">
+            <h2 class="text-2xl font-semibold mb-4">Did you mean one of these?</h2>
+            <div class="space-y-4">
+                @for (var i = 0; i < Model.Suggestions.Count; i++)
+                {
+                    var suggestion = Model.Suggestions[i];
+                    var suggestionUrl = $"/blog/{(suggestion.Language != "en" ? suggestion.Language + "/" : "")}{suggestion.Slug}";
+
+                    <div class="border border-gray-200 dark:border-gray-700 rounded-lg p-4 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+                        <h3 class="text-xl font-semibold mb-2">
+                            <a href="@suggestionUrl"
+                               class="text-blue-600 dark:text-blue-400 hover:underline suggestion-link"
+                               data-requested-slug="@Model.OriginalPath"
+                               data-clicked-slug="@suggestion.Slug"
+                               data-language="@suggestion.Language"
+                               data-position="@i"
+                               data-score="0.5"
+                               onclick="trackSuggestionClick(this, event)">
+                                @suggestion.Title
+                            </a>
+                        </h3>
+                        @if (suggestion.Categories?.Any() == true)
+                        {
+                            <div class="flex flex-wrap gap-2 mb-2">
+                                @foreach (var category in suggestion.Categories)
+                                {
+                                    <span class="inline-block bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 text-xs px-2 py-1 rounded">
+                                        @category
+                                    </span>
+                                }
+                            </div>
+                        }
+                        <p class="text-sm text-gray-600 dark:text-gray-400">
+                            Published: @suggestion.PublishedDate.ToString("MMMM dd, yyyy")
+                        </p>
+                    </div>
+                }
+            </div>
+        </div>
+    }
+    else
+    {
+        <div class="mt-8">
+            <p class="text-gray-600 dark:text-gray-400">
+                Try visiting the <a href="/" class="text-blue-600 dark:text-blue-400 hover:underline">home page</a>
+                or use the search feature to find what you're looking for.
+            </p>
+        </div>
+    }
+</div>
+
 @section Scripts {
     <script>
             document.addEventListener('DOMContentLoaded', function () {
@@ -12,5 +74,36 @@
                 }
             });
 
+            // Track suggestion clicks for machine learning
+            function trackSuggestionClick(link, event) {
+                const requestedSlug = link.getAttribute('data-requested-slug');
+                const clickedSlug = link.getAttribute('data-clicked-slug');
+                const language = link.getAttribute('data-language');
+                const position = parseInt(link.getAttribute('data-position'));
+                const score = parseFloat(link.getAttribute('data-score'));
+
+                // Send tracking request asynchronously (don't wait for response)
+                fetch('/api/slugsuggestion/track-click', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-TOKEN': document.querySelector('input[name="__RequestVerificationToken"]')?.value || ''
+                    },
+                    body: JSON.stringify({
+                        requestedSlug: requestedSlug,
+                        clickedSlug: clickedSlug,
+                        language: language,
+                        suggestionPosition: position,
+                        originalScore: score
+                    }),
+                    keepalive: true // Ensure request completes even if user navigates away
+                }).catch(err => {
+                    // Silently fail - don't interrupt navigation
+                    console.debug('Failed to track suggestion click:', err);
+                });
+
+                // Allow navigation to proceed
+                return true;
+            }
     </script>
 }


### PR DESCRIPTION
Implements a comprehensive 404 error handling system that learns from user behavior:

Core Features:
- Fuzzy string matching using Levenshtein distance algorithm
- Intelligent slug suggestions based on similarity scores
- Machine learning system that learns from user clicks
- Automatic 301 redirects when confidence threshold is reached

New Components:
1. SlugSuggestionService - Core service with Levenshtein distance algorithm
   - Calculates similarity scores with prefix/substring bonuses
   - Incorporates learned weights to boost relevant suggestions
   - Tracks confidence scores and auto-redirect eligibility

2. Database Entities:
   - SlugRedirectEntity - Tracks slug mappings with weights and confidence
   - SlugSuggestionClickEntity - Records individual click events for analytics
   - Auto-redirect enabled after 5 clicks with >70% confidence

3. API Endpoint:
   - POST /api/slugsuggestion/track-click - Records user clicks on suggestions
   - Asynchronous tracking to avoid blocking navigation

4. SlugRedirectMiddleware:
   - Intercepts blog post requests before 404
   - Provides 301 Permanent Redirect for learned mappings
   - Runs before status code pages middleware

5. Enhanced 404 Page:
   - Displays up to 5 intelligent suggestions
   - JavaScript tracking on suggestion clicks
   - Maintains original Umami analytics integration

Implementation Details:
- Minimum similarity threshold: 0.4
- Learned weight boost: 0.3 * confidence score
- Auto-redirect threshold: 5 clicks + 70% confidence
- Supports multi-language blog posts

Benefits:
- Improves user experience by suggesting correct pages
- Reduces bounce rate from typos and outdated links
- Self-improving system that learns from user behavior
- SEO-friendly with proper 301 redirects for learned mappings

🤖 Generated with [Claude Code](https://claude.com/claude-code)