### PR TITLE
Create RAG-assisted LLM document translator package

### DIFF
--- a/Mostlylucid.sln
+++ b/Mostlylucid.sln
@@ -74,6 +74,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mostlylucid.BotDetection", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mostlylucid.BotDetection.Demo", "Mostlylucid.BotDetection.Demo\Mostlylucid.BotDetection.Demo.csproj", "{0D1E2F3A-4B5C-6D7E-8F9A-0B1C2D3E4F5A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "mostlylucid.llmslidetranslator", "mostlylucid.llmslidetranslator\mostlylucid.llmslidetranslator.csproj", "{A1B2C3D4-E5F6-4789-ABCD-EF1234567890}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "mostlylucid.llmslidetranslator.Demo", "mostlylucid.llmslidetranslator.Demo\mostlylucid.llmslidetranslator.Demo.csproj", "{B2C3D4E5-F6A7-4890-BCDE-F12345678901}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -420,6 +424,30 @@ Global
 		{0D1E2F3A-4B5C-6D7E-8F9A-0B1C2D3E4F5A}.Release|x64.Build.0 = Release|Any CPU
 		{0D1E2F3A-4B5C-6D7E-8F9A-0B1C2D3E4F5A}.Release|x86.ActiveCfg = Release|Any CPU
 		{0D1E2F3A-4B5C-6D7E-8F9A-0B1C2D3E4F5A}.Release|x86.Build.0 = Release|Any CPU
+		{A1B2C3D4-E5F6-4789-ABCD-EF1234567890}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-E5F6-4789-ABCD-EF1234567890}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1B2C3D4-E5F6-4789-ABCD-EF1234567890}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-E5F6-4789-ABCD-EF1234567890}.Debug|x64.Build.0 = Debug|Any CPU
+		{A1B2C3D4-E5F6-4789-ABCD-EF1234567890}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-E5F6-4789-ABCD-EF1234567890}.Debug|x86.Build.0 = Debug|Any CPU
+		{A1B2C3D4-E5F6-4789-ABCD-EF1234567890}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-E5F6-4789-ABCD-EF1234567890}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1B2C3D4-E5F6-4789-ABCD-EF1234567890}.Release|x64.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-E5F6-4789-ABCD-EF1234567890}.Release|x64.Build.0 = Release|Any CPU
+		{A1B2C3D4-E5F6-4789-ABCD-EF1234567890}.Release|x86.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-E5F6-4789-ABCD-EF1234567890}.Release|x86.Build.0 = Release|Any CPU
+		{B2C3D4E5-F6A7-4890-BCDE-F12345678901}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B2C3D4E5-F6A7-4890-BCDE-F12345678901}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B2C3D4E5-F6A7-4890-BCDE-F12345678901}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B2C3D4E5-F6A7-4890-BCDE-F12345678901}.Debug|x64.Build.0 = Debug|Any CPU
+		{B2C3D4E5-F6A7-4890-BCDE-F12345678901}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B2C3D4E5-F6A7-4890-BCDE-F12345678901}.Debug|x86.Build.0 = Debug|Any CPU
+		{B2C3D4E5-F6A7-4890-BCDE-F12345678901}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B2C3D4E5-F6A7-4890-BCDE-F12345678901}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B2C3D4E5-F6A7-4890-BCDE-F12345678901}.Release|x64.ActiveCfg = Release|Any CPU
+		{B2C3D4E5-F6A7-4890-BCDE-F12345678901}.Release|x64.Build.0 = Release|Any CPU
+		{B2C3D4E5-F6A7-4890-BCDE-F12345678901}.Release|x86.ActiveCfg = Release|Any CPU
+		{B2C3D4E5-F6A7-4890-BCDE-F12345678901}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/mostlylucid.llmslidetranslator.Demo/Hubs/TranslationHub.cs
+++ b/mostlylucid.llmslidetranslator.Demo/Hubs/TranslationHub.cs
@@ -1,0 +1,48 @@
+using Microsoft.AspNetCore.SignalR;
+
+namespace mostlylucid.llmslidetranslator.Demo.Hubs;
+
+/// <summary>
+/// SignalR hub for real-time translation updates
+/// </summary>
+public class TranslationHub : Hub
+{
+    private readonly ILogger<TranslationHub> _logger;
+
+    public TranslationHub(ILogger<TranslationHub> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Subscribe to updates for a specific document
+    /// </summary>
+    public async Task SubscribeToDocument(string documentId)
+    {
+        await Groups.AddToGroupAsync(Context.ConnectionId, $"document_{documentId}");
+        _logger.LogInformation("Client {ConnectionId} subscribed to document {DocumentId}",
+            Context.ConnectionId, documentId);
+    }
+
+    /// <summary>
+    /// Unsubscribe from updates for a specific document
+    /// </summary>
+    public async Task UnsubscribeFromDocument(string documentId)
+    {
+        await Groups.RemoveFromGroupAsync(Context.ConnectionId, $"document_{documentId}");
+        _logger.LogInformation("Client {ConnectionId} unsubscribed from document {DocumentId}",
+            Context.ConnectionId, documentId);
+    }
+
+    public override async Task OnConnectedAsync()
+    {
+        _logger.LogInformation("Client connected: {ConnectionId}", Context.ConnectionId);
+        await base.OnConnectedAsync();
+    }
+
+    public override async Task OnDisconnectedAsync(Exception? exception)
+    {
+        _logger.LogInformation("Client disconnected: {ConnectionId}", Context.ConnectionId);
+        await base.OnDisconnectedAsync(exception);
+    }
+}

--- a/mostlylucid.llmslidetranslator.Demo/Program.cs
+++ b/mostlylucid.llmslidetranslator.Demo/Program.cs
@@ -1,0 +1,184 @@
+using mostlylucid.llmslidetranslator.Demo.Hubs;
+using mostlylucid.llmslidetranslator.Demo.Services;
+using mostlylucid.llmslidetranslator.Extensions;
+using mostlylucid.llmslidetranslator.Models;
+using mostlylucid.llmslidetranslator.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+// Add SignalR
+builder.Services.AddSignalR();
+
+// Add CORS for SignalR
+builder.Services.AddCors(options =>
+{
+    options.AddDefaultPolicy(policy =>
+    {
+        policy.AllowAnyOrigin()
+              .AllowAnyMethod()
+              .AllowAnyHeader();
+    });
+});
+
+// Add LLM Slide Translator services
+builder.Services.AddLlmSlideTranslator(builder.Configuration);
+
+// Add streaming translation service
+builder.Services.AddSingleton<StreamingTranslationService>();
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseCors();
+
+// Serve static files
+app.UseStaticFiles();
+app.UseDefaultFiles();
+
+// Map SignalR hub
+app.MapHub<TranslationHub>("/hubs/translation");
+
+// Health check endpoint
+app.MapGet("/health", () => Results.Ok(new { Status = "Healthy", Service = "LLM Slide Translator Demo API" }))
+    .WithName("Health")
+    .WithOpenApi();
+
+// Translate document (standard endpoint)
+app.MapPost("/translate", async (
+    TranslateRequest request,
+    ILlmSlideTranslator translator) =>
+{
+    var result = await translator.TranslateAsync(
+        request.Markdown,
+        request.DocumentId,
+        request.SourceLanguage,
+        request.TargetLanguage,
+        request.Method);
+
+    return Results.Ok(result);
+})
+.WithName("Translate")
+.WithOpenApi();
+
+// Stream translation (SSE endpoint)
+app.MapGet("/translate/stream/{documentId}", async (
+    string documentId,
+    string markdown,
+    string sourceLanguage,
+    string targetLanguage,
+    TranslationMethod method,
+    StreamingTranslationService streamingService,
+    HttpContext context) =>
+{
+    context.Response.Headers.ContentType = "text/event-stream";
+    context.Response.Headers.CacheControl = "no-cache";
+
+    await foreach (var update in streamingService.StreamTranslationAsync(
+        markdown, documentId, sourceLanguage, targetLanguage, method))
+    {
+        var json = System.Text.Json.JsonSerializer.Serialize(update);
+        await context.Response.WriteAsync($"data: {json}\n\n");
+        await context.Response.Body.FlushAsync();
+    }
+})
+.WithName("StreamTranslation")
+.WithOpenApi();
+
+// Compare translations
+app.MapPost("/compare", async (
+    CompareRequest request,
+    ILlmSlideTranslator translator,
+    ITranslationComparer comparer) =>
+{
+    // Translate with method 1
+    var result1 = await translator.TranslateAsync(
+        request.Markdown,
+        request.DocumentId + "_method1",
+        request.SourceLanguage,
+        request.TargetLanguage,
+        request.Method1);
+
+    // Translate with method 2
+    var result2 = await translator.TranslateAsync(
+        request.Markdown,
+        request.DocumentId + "_method2",
+        request.SourceLanguage,
+        request.TargetLanguage,
+        request.Method2);
+
+    // Compare
+    var comparison = await comparer.CompareAsync(result1, result2);
+
+    return Results.Ok(comparison);
+})
+.WithName("CompareTranslations")
+.WithOpenApi();
+
+// Get translation progress
+app.MapGet("/translate/{documentId}/progress", async (
+    string documentId,
+    ILlmSlideTranslator translator) =>
+{
+    var progress = await translator.GetProgressAsync(documentId);
+    return Results.Ok(progress);
+})
+.WithName("GetProgress")
+.WithOpenApi();
+
+// Check service availability
+app.MapGet("/services/status", async (
+    IOllamaClient ollamaClient,
+    INmtClient nmtClient) =>
+{
+    var ollamaAvailable = await ollamaClient.IsAvailableAsync();
+    var nmtAvailable = await nmtClient.IsAvailableAsync();
+
+    List<string>? ollamaModels = null;
+    if (ollamaAvailable)
+    {
+        ollamaModels = await ollamaClient.GetModelsAsync();
+    }
+
+    return Results.Ok(new
+    {
+        Ollama = new
+        {
+            Available = ollamaAvailable,
+            Models = ollamaModels
+        },
+        Nmt = new
+        {
+            Available = nmtAvailable
+        }
+    });
+})
+.WithName("ServiceStatus")
+.WithOpenApi();
+
+app.Run();
+
+// Request DTOs
+record TranslateRequest(
+    string Markdown,
+    string DocumentId,
+    string SourceLanguage = "en",
+    string TargetLanguage = "de",
+    TranslationMethod Method = TranslationMethod.RagLlm);
+
+record CompareRequest(
+    string Markdown,
+    string DocumentId,
+    string SourceLanguage,
+    string TargetLanguage,
+    TranslationMethod Method1,
+    TranslationMethod Method2);

--- a/mostlylucid.llmslidetranslator.Demo/Services/StreamingTranslationService.cs
+++ b/mostlylucid.llmslidetranslator.Demo/Services/StreamingTranslationService.cs
@@ -1,0 +1,227 @@
+using System.Diagnostics;
+using Microsoft.AspNetCore.SignalR;
+using mostlylucid.llmslidetranslator.Demo.Hubs;
+using mostlylucid.llmslidetranslator.Models;
+using mostlylucid.llmslidetranslator.Services;
+
+namespace mostlylucid.llmslidetranslator.Demo.Services;
+
+/// <summary>
+/// Service for streaming translations with real-time updates via SignalR
+/// </summary>
+public class StreamingTranslationService
+{
+    private readonly ILogger<StreamingTranslationService> _logger;
+    private readonly IHubContext<TranslationHub> _hubContext;
+    private readonly IServiceScopeFactory _scopeFactory;
+
+    public StreamingTranslationService(
+        ILogger<StreamingTranslationService> logger,
+        IHubContext<TranslationHub> hubContext,
+        IServiceScopeFactory scopeFactory)
+    {
+        _logger = logger;
+        _hubContext = hubContext;
+        _scopeFactory = scopeFactory;
+    }
+
+    /// <summary>
+    /// Stream translation of a document with real-time updates
+    /// </summary>
+    public async IAsyncEnumerable<TranslationUpdate> StreamTranslationAsync(
+        string markdown,
+        string documentId,
+        string sourceLanguage,
+        string targetLanguage,
+        TranslationMethod method)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        var groupName = $"document_{documentId}";
+
+        _logger.LogInformation("Starting streaming translation for document {DocumentId}", documentId);
+
+        // Send start notification
+        await _hubContext.Clients.Group(groupName).SendAsync("TranslationStarted", new
+        {
+            DocumentId = documentId,
+            SourceLanguage = sourceLanguage,
+            TargetLanguage = targetLanguage,
+            Method = method.ToString()
+        });
+
+        yield return new TranslationUpdate
+        {
+            DocumentId = documentId,
+            Status = "Started",
+            Message = "Translation started"
+        };
+
+        using var scope = _scopeFactory.CreateScope();
+        var translator = scope.ServiceProvider.GetRequiredService<ILlmSlideTranslator>();
+        var chunker = scope.ServiceProvider.GetRequiredService<IMarkdownChunker>();
+        var embeddingGenerator = scope.ServiceProvider.GetRequiredService<IEmbeddingGenerator>();
+        var vectorStore = scope.ServiceProvider.GetRequiredService<IVectorStore>();
+
+        try
+        {
+            // Step 1: Chunk
+            yield return new TranslationUpdate
+            {
+                DocumentId = documentId,
+                Status = "Chunking",
+                Message = "Breaking document into blocks..."
+            };
+
+            var blocks = await chunker.ChunkAsync(markdown, documentId, sourceLanguage, targetLanguage);
+
+            await _hubContext.Clients.Group(groupName).SendAsync("ChunkingComplete", new
+            {
+                DocumentId = documentId,
+                BlockCount = blocks.Count
+            });
+
+            yield return new TranslationUpdate
+            {
+                DocumentId = documentId,
+                Status = "Chunked",
+                Message = $"Created {blocks.Count} blocks",
+                Progress = new { TotalBlocks = blocks.Count, CurrentBlock = 0 }
+            };
+
+            // Step 2: Generate embeddings
+            yield return new TranslationUpdate
+            {
+                DocumentId = documentId,
+                Status = "Embedding",
+                Message = "Generating embeddings..."
+            };
+
+            blocks = await embeddingGenerator.GenerateEmbeddingsAsync(blocks);
+
+            await _hubContext.Clients.Group(groupName).SendAsync("EmbeddingComplete", new
+            {
+                DocumentId = documentId
+            });
+
+            // Step 3: Store
+            await vectorStore.StoreAsync(blocks, documentId);
+
+            // Step 4: Translate block by block
+            TranslationBlock? previousBlock = null;
+            var translatedBlocks = new List<TranslationBlock>();
+
+            for (int i = 0; i < blocks.Count; i++)
+            {
+                var block = blocks[i];
+
+                yield return new TranslationUpdate
+                {
+                    DocumentId = documentId,
+                    Status = "Translating",
+                    Message = $"Translating block {i + 1} of {blocks.Count}",
+                    Progress = new
+                    {
+                        TotalBlocks = blocks.Count,
+                        CurrentBlock = i + 1,
+                        PercentComplete = (float)(i + 1) / blocks.Count * 100
+                    }
+                };
+
+                await _hubContext.Clients.Group(groupName).SendAsync("BlockTranslationStarted", new
+                {
+                    DocumentId = documentId,
+                    BlockIndex = i,
+                    BlockId = block.BlockId
+                });
+
+                var translatedBlock = await translator.TranslateBlockAsync(block, previousBlock);
+                translatedBlocks.Add(translatedBlock);
+
+                await _hubContext.Clients.Group(groupName).SendAsync("BlockTranslationComplete", new
+                {
+                    DocumentId = documentId,
+                    BlockIndex = i,
+                    BlockId = block.BlockId,
+                    OriginalText = block.Text,
+                    TranslatedText = translatedBlock.TranslatedText
+                });
+
+                yield return new TranslationUpdate
+                {
+                    DocumentId = documentId,
+                    Status = "BlockComplete",
+                    Message = $"Block {i + 1} translated",
+                    Progress = new
+                    {
+                        TotalBlocks = blocks.Count,
+                        CurrentBlock = i + 1,
+                        PercentComplete = (float)(i + 1) / blocks.Count * 100
+                    },
+                    Data = new
+                    {
+                        BlockIndex = i,
+                        OriginalText = block.Text,
+                        TranslatedText = translatedBlock.TranslatedText
+                    }
+                };
+
+                previousBlock = translatedBlock;
+            }
+
+            // Update vector store with translations
+            await vectorStore.StoreAsync(translatedBlocks, documentId);
+
+            stopwatch.Stop();
+
+            // Send completion notification
+            await _hubContext.Clients.Group(groupName).SendAsync("TranslationComplete", new
+            {
+                DocumentId = documentId,
+                Duration = stopwatch.Elapsed.TotalSeconds,
+                BlockCount = translatedBlocks.Count
+            });
+
+            yield return new TranslationUpdate
+            {
+                DocumentId = documentId,
+                Status = "Complete",
+                Message = $"Translation completed in {stopwatch.Elapsed.TotalSeconds:F2}s",
+                Progress = new
+                {
+                    TotalBlocks = blocks.Count,
+                    CurrentBlock = blocks.Count,
+                    PercentComplete = 100
+                }
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error during streaming translation of document {DocumentId}", documentId);
+
+            await _hubContext.Clients.Group(groupName).SendAsync("TranslationError", new
+            {
+                DocumentId = documentId,
+                Error = ex.Message
+            });
+
+            yield return new TranslationUpdate
+            {
+                DocumentId = documentId,
+                Status = "Error",
+                Message = ex.Message
+            };
+        }
+    }
+}
+
+/// <summary>
+/// Real-time translation update
+/// </summary>
+public class TranslationUpdate
+{
+    public required string DocumentId { get; set; }
+    public required string Status { get; set; }
+    public required string Message { get; set; }
+    public object? Progress { get; set; }
+    public object? Data { get; set; }
+}

--- a/mostlylucid.llmslidetranslator.Demo/appsettings.json
+++ b/mostlylucid.llmslidetranslator.Demo/appsettings.json
@@ -1,0 +1,55 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.AspNetCore.SignalR": "Information"
+    }
+  },
+  "AllowedHosts": "*",
+
+  "LlmSlideTranslator": {
+    "Ollama": {
+      "Endpoint": "http://localhost:11434",
+      "Model": "llama3.2:3b",
+      "Temperature": 0.3,
+      "MaxTokens": 2048,
+      "TimeoutSeconds": 120
+    },
+
+    "Nmt": {
+      "Enabled": true,
+      "ServiceEndpoints": [
+        "http://localhost:24080"
+      ],
+      "UseAsBaseline": true
+    },
+
+    "Embedding": {
+      "ModelPath": "./models/nomic-embed-text-v1.5.Q8_0.gguf",
+      "Dimension": 768,
+      "ContextSize": 2048,
+      "BatchSize": 512
+    },
+
+    "Rag": {
+      "TopK": 3,
+      "UseSlidingWindow": true,
+      "MinSimilarity": 0.5,
+      "MaxContextBlocks": 5
+    },
+
+    "DataPath": "./data",
+    "DefaultSourceLanguage": "en",
+    "DefaultTargetLanguage": "de",
+
+    "VectorStoreProvider": "File",
+
+    "Qdrant": {
+      "Endpoint": "http://localhost:6333",
+      "ApiKey": null,
+      "CollectionName": "translations",
+      "UseHttps": false
+    }
+  }
+}

--- a/mostlylucid.llmslidetranslator.Demo/mostlylucid.llmslidetranslator.Demo.csproj
+++ b/mostlylucid.llmslidetranslator.Demo/mostlylucid.llmslidetranslator.Demo.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <RootNamespace>mostlylucid.llmslidetranslator.Demo</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.10" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="9.0.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\mostlylucid.llmslidetranslator\mostlylucid.llmslidetranslator.csproj" />
+    </ItemGroup>
+</Project>

--- a/mostlylucid.llmslidetranslator.Demo/wwwroot/index.html
+++ b/mostlylucid.llmslidetranslator.Demo/wwwroot/index.html
@@ -1,0 +1,378 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>LLM Slide Translator Demo</title>
+    <script src="https://cdn.jsdelivr.net/npm/@microsoft/signalr@8.0.0/dist/browser/signalr.min.js"></script>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 20px;
+            background: #f5f5f5;
+        }
+        h1 {
+            color: #333;
+        }
+        .container {
+            background: white;
+            border-radius: 8px;
+            padding: 20px;
+            margin-bottom: 20px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        textarea {
+            width: 100%;
+            min-height: 200px;
+            padding: 10px;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+            font-family: monospace;
+            resize: vertical;
+        }
+        input, select {
+            padding: 8px;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+            margin-right: 10px;
+        }
+        button {
+            background: #007bff;
+            color: white;
+            border: none;
+            padding: 10px 20px;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 14px;
+        }
+        button:hover {
+            background: #0056b3;
+        }
+        button:disabled {
+            background: #ccc;
+            cursor: not-allowed;
+        }
+        .progress {
+            width: 100%;
+            height: 30px;
+            background: #f0f0f0;
+            border-radius: 4px;
+            overflow: hidden;
+            margin: 10px 0;
+        }
+        .progress-bar {
+            height: 100%;
+            background: #007bff;
+            transition: width 0.3s ease;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: white;
+            font-weight: bold;
+        }
+        .status {
+            padding: 10px;
+            border-radius: 4px;
+            margin: 10px 0;
+        }
+        .status.info {
+            background: #d1ecf1;
+            color: #0c5460;
+        }
+        .status.success {
+            background: #d4edda;
+            color: #155724;
+        }
+        .status.error {
+            background: #f8d7da;
+            color: #721c24;
+        }
+        .log {
+            max-height: 300px;
+            overflow-y: auto;
+            background: #f8f9fa;
+            padding: 10px;
+            border-radius: 4px;
+            font-family: monospace;
+            font-size: 12px;
+        }
+        .log-entry {
+            padding: 4px 0;
+            border-bottom: 1px solid #e0e0e0;
+        }
+        .log-entry:last-child {
+            border-bottom: none;
+        }
+        .translation-output {
+            background: #f8f9fa;
+            padding: 15px;
+            border-radius: 4px;
+            white-space: pre-wrap;
+            font-family: 'Georgia', serif;
+            line-height: 1.6;
+        }
+    </style>
+</head>
+<body>
+    <h1>🌐 LLM Slide Translator Demo</h1>
+
+    <div class="container">
+        <h2>Configuration</h2>
+        <label>
+            Document ID:
+            <input type="text" id="documentId" value="doc_001" />
+        </label>
+        <label>
+            Source Language:
+            <input type="text" id="sourceLang" value="en" />
+        </label>
+        <label>
+            Target Language:
+            <input type="text" id="targetLang" value="de" />
+        </label>
+        <label>
+            Translation Method:
+            <select id="method">
+                <option value="0">LLM Only</option>
+                <option value="1">NMT Only</option>
+                <option value="2">NMT + LLM</option>
+                <option value="3" selected>RAG + LLM (Recommended)</option>
+            </select>
+        </label>
+    </div>
+
+    <div class="container">
+        <h2>Input Document</h2>
+        <textarea id="markdown" placeholder="Enter markdown content here...">
+# My Technical Blog Post
+
+This is an introduction paragraph about building scalable web applications.
+
+## Architecture
+
+We use a microservices architecture with the following components:
+- API Gateway
+- User Service
+- Payment Service
+- Notification Service
+
+## Implementation Details
+
+The implementation uses Docker containers for deployment and Kubernetes for orchestration.
+
+### Database Schema
+
+Each service has its own PostgreSQL database to maintain separation of concerns.
+        </textarea>
+    </div>
+
+    <div class="container">
+        <h2>Translation</h2>
+        <button id="translateBtn" onclick="startTranslation()">🚀 Start Translation</button>
+        <button id="subscribeBtn" onclick="subscribeToUpdates()">📡 Subscribe to Updates</button>
+        <button id="unsubscribeBtn" onclick="unsubscribeFromUpdates()">🔇 Unsubscribe</button>
+
+        <div id="statusBox" class="status info" style="display: none;">
+            <strong id="statusText">Ready</strong>
+        </div>
+
+        <div class="progress" style="display: none;" id="progressBox">
+            <div class="progress-bar" id="progressBar" style="width: 0%">0%</div>
+        </div>
+    </div>
+
+    <div class="container">
+        <h2>Activity Log</h2>
+        <div id="log" class="log"></div>
+    </div>
+
+    <div class="container">
+        <h2>Translated Output</h2>
+        <div id="output" class="translation-output">Translation will appear here...</div>
+    </div>
+
+    <script>
+        let connection = null;
+        let isSubscribed = false;
+        let translatedBlocks = [];
+
+        // Initialize SignalR connection
+        async function initConnection() {
+            if (connection) return;
+
+            connection = new signalR.HubConnectionBuilder()
+                .withUrl("/hubs/translation")
+                .withAutomaticReconnect()
+                .build();
+
+            // Set up event handlers
+            connection.on("TranslationStarted", (data) => {
+                log(`Translation started: ${data.documentId} (${data.sourceLanguage} → ${data.targetLanguage})`);
+                showStatus("Translation started...", "info");
+            });
+
+            connection.on("ChunkingComplete", (data) => {
+                log(`Chunked into ${data.blockCount} blocks`);
+            });
+
+            connection.on("EmbeddingComplete", (data) => {
+                log(`Embeddings generated for ${data.documentId}`);
+            });
+
+            connection.on("BlockTranslationStarted", (data) => {
+                log(`Translating block ${data.blockIndex + 1}...`);
+            });
+
+            connection.on("BlockTranslationComplete", (data) => {
+                log(`✓ Block ${data.blockIndex + 1} complete`);
+                translatedBlocks[data.blockIndex] = data.translatedText;
+                updateOutput();
+            });
+
+            connection.on("TranslationComplete", (data) => {
+                log(`✅ Translation complete in ${data.duration.toFixed(2)}s`);
+                showStatus(`Translation completed successfully!`, "success");
+                document.getElementById("progressBox").style.display = "none";
+            });
+
+            connection.on("TranslationError", (data) => {
+                log(`❌ Error: ${data.error}`);
+                showStatus(`Error: ${data.error}`, "error");
+            });
+
+            try {
+                await connection.start();
+                log("✓ Connected to SignalR hub");
+            } catch (err) {
+                log(`✗ Connection error: ${err}`);
+            }
+        }
+
+        async function subscribeToUpdates() {
+            if (!connection) await initConnection();
+
+            const documentId = document.getElementById("documentId").value;
+            try {
+                await connection.invoke("SubscribeToDocument", documentId);
+                log(`📡 Subscribed to document: ${documentId}`);
+                isSubscribed = true;
+                document.getElementById("subscribeBtn").disabled = true;
+                document.getElementById("unsubscribeBtn").disabled = false;
+            } catch (err) {
+                log(`✗ Subscribe error: ${err}`);
+            }
+        }
+
+        async function unsubscribeFromUpdates() {
+            if (!connection) return;
+
+            const documentId = document.getElementById("documentId").value;
+            try {
+                await connection.invoke("UnsubscribeFromDocument", documentId);
+                log(`🔇 Unsubscribed from document: ${documentId}`);
+                isSubscribed = false;
+                document.getElementById("subscribeBtn").disabled = false;
+                document.getElementById("unsubscribeBtn").disabled = true;
+            } catch (err) {
+                log(`✗ Unsubscribe error: ${err}`);
+            }
+        }
+
+        async function startTranslation() {
+            const documentId = document.getElementById("documentId").value;
+            const markdown = document.getElementById("markdown").value;
+            const sourceLang = document.getElementById("sourceLang").value;
+            const targetLang = document.getElementById("targetLang").value;
+            const method = parseInt(document.getElementById("method").value);
+
+            translatedBlocks = [];
+            document.getElementById("output").textContent = "";
+            document.getElementById("progressBox").style.display = "block";
+
+            if (!isSubscribed) {
+                await subscribeToUpdates();
+            }
+
+            // Use fetch with streaming
+            const url = `/translate/stream/${documentId}?markdown=${encodeURIComponent(markdown)}&sourceLanguage=${sourceLang}&targetLanguage=${targetLang}&method=${method}`;
+
+            try {
+                const response = await fetch(url);
+                const reader = response.body.getReader();
+                const decoder = new TextDecoder();
+
+                while (true) {
+                    const { value, done } = await reader.read();
+                    if (done) break;
+
+                    const chunk = decoder.decode(value);
+                    const lines = chunk.split('\n');
+
+                    for (const line of lines) {
+                        if (line.startsWith('data: ')) {
+                            const data = JSON.parse(line.substring(6));
+                            handleStreamUpdate(data);
+                        }
+                    }
+                }
+            } catch (err) {
+                log(`❌ Streaming error: ${err}`);
+                showStatus(`Error: ${err}`, "error");
+            }
+        }
+
+        function handleStreamUpdate(data) {
+            log(`[${data.status}] ${data.message}`);
+
+            if (data.progress) {
+                const percent = data.progress.percentComplete || 0;
+                document.getElementById("progressBar").style.width = `${percent}%`;
+                document.getElementById("progressBar").textContent = `${Math.round(percent)}%`;
+            }
+
+            if (data.data && data.data.translatedText) {
+                translatedBlocks[data.data.blockIndex] = data.data.translatedText;
+                updateOutput();
+            }
+
+            if (data.status === "Complete") {
+                showStatus(data.message, "success");
+            } else if (data.status === "Error") {
+                showStatus(data.message, "error");
+            } else {
+                showStatus(data.message, "info");
+            }
+        }
+
+        function updateOutput() {
+            const output = translatedBlocks.filter(b => b).join('\n\n');
+            document.getElementById("output").textContent = output;
+        }
+
+        function log(message) {
+            const logDiv = document.getElementById("log");
+            const entry = document.createElement("div");
+            entry.className = "log-entry";
+            entry.textContent = `[${new Date().toLocaleTimeString()}] ${message}`;
+            logDiv.appendChild(entry);
+            logDiv.scrollTop = logDiv.scrollHeight;
+        }
+
+        function showStatus(text, type) {
+            const statusBox = document.getElementById("statusBox");
+            const statusText = document.getElementById("statusText");
+            statusBox.style.display = "block";
+            statusBox.className = `status ${type}`;
+            statusText.textContent = text;
+        }
+
+        // Initialize on page load
+        window.onload = () => {
+            log("Demo client loaded");
+            document.getElementById("unsubscribeBtn").disabled = true;
+        };
+    </script>
+</body>
+</html>

--- a/mostlylucid.llmslidetranslator/Extensions/ServiceCollectionExtensions.cs
+++ b/mostlylucid.llmslidetranslator/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,93 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Configuration;
+using mostlylucid.llmslidetranslator.Models;
+using mostlylucid.llmslidetranslator.Services;
+
+namespace mostlylucid.llmslidetranslator.Extensions;
+
+/// <summary>
+/// Extension methods for configuring LLM Slide Translator services
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Add LLM Slide Translator services to the DI container
+    /// </summary>
+    /// <param name="services">Service collection</param>
+    /// <param name="configuration">Configuration</param>
+    /// <param name="sectionName">Configuration section name (default: "LlmSlideTranslator")</param>
+    /// <returns>Service collection for chaining</returns>
+    public static IServiceCollection AddLlmSlideTranslator(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        string sectionName = "LlmSlideTranslator")
+    {
+        // Bind configuration
+        services.Configure<LlmSlideTranslatorConfig>(configuration.GetSection(sectionName));
+
+        // Register core services
+        services.AddSingleton<IMarkdownChunker, MarkdownChunker>();
+        services.AddSingleton<IEmbeddingGenerator, EmbeddingGenerator>();
+        services.AddSingleton<ITranslationComparer, TranslationComparer>();
+
+        // Register vector store based on configuration
+        var config = configuration.GetSection(sectionName).Get<LlmSlideTranslatorConfig>();
+        if (config?.VectorStoreProvider?.Equals("Qdrant", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            services.AddSingleton<IVectorStore, QdrantVectorStore>();
+        }
+        else
+        {
+            services.AddSingleton<IVectorStore, FileVectorStore>();
+        }
+
+        // Register HTTP clients
+        services.AddHttpClient<IOllamaClient, OllamaClient>();
+        services.AddHttpClient<INmtClient, NmtClient>();
+
+        // Register main translator
+        services.AddScoped<ILlmSlideTranslator, LlmSlideTranslator>();
+
+        return services;
+    }
+
+    /// <summary>
+    /// Add LLM Slide Translator services with custom configuration
+    /// </summary>
+    /// <param name="services">Service collection</param>
+    /// <param name="configureOptions">Configuration action</param>
+    /// <returns>Service collection for chaining</returns>
+    public static IServiceCollection AddLlmSlideTranslator(
+        this IServiceCollection services,
+        Action<LlmSlideTranslatorConfig> configureOptions)
+    {
+        services.Configure(configureOptions);
+
+        // Register core services
+        services.AddSingleton<IMarkdownChunker, MarkdownChunker>();
+        services.AddSingleton<IEmbeddingGenerator, EmbeddingGenerator>();
+        services.AddSingleton<ITranslationComparer, TranslationComparer>();
+
+        // Determine vector store provider from configuration
+        var config = new LlmSlideTranslatorConfig();
+        configureOptions(config);
+
+        if (config.VectorStoreProvider?.Equals("Qdrant", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            services.AddSingleton<IVectorStore, QdrantVectorStore>();
+        }
+        else
+        {
+            services.AddSingleton<IVectorStore, FileVectorStore>();
+        }
+
+        // Register HTTP clients
+        services.AddHttpClient<IOllamaClient, OllamaClient>();
+        services.AddHttpClient<INmtClient, NmtClient>();
+
+        // Register main translator
+        services.AddScoped<ILlmSlideTranslator, LlmSlideTranslator>();
+
+        return services;
+    }
+}

--- a/mostlylucid.llmslidetranslator/Models/LlmSlideTranslatorConfig.cs
+++ b/mostlylucid.llmslidetranslator/Models/LlmSlideTranslatorConfig.cs
@@ -1,0 +1,182 @@
+namespace mostlylucid.llmslidetranslator.Models;
+
+/// <summary>
+/// Configuration for the LLM Slide Translator
+/// </summary>
+public class LlmSlideTranslatorConfig
+{
+    /// <summary>
+    /// Ollama configuration
+    /// </summary>
+    public OllamaConfig Ollama { get; set; } = new();
+
+    /// <summary>
+    /// NMT (Neural Machine Translation) configuration
+    /// </summary>
+    public NmtConfig Nmt { get; set; } = new();
+
+    /// <summary>
+    /// Embedding configuration
+    /// </summary>
+    public EmbeddingConfig Embedding { get; set; } = new();
+
+    /// <summary>
+    /// RAG configuration
+    /// </summary>
+    public RagConfig Rag { get; set; } = new();
+
+    /// <summary>
+    /// Path to store embeddings and vector indices
+    /// </summary>
+    public string DataPath { get; set; } = "./data";
+
+    /// <summary>
+    /// Default source language
+    /// </summary>
+    public string DefaultSourceLanguage { get; set; } = "en";
+
+    /// <summary>
+    /// Default target language
+    /// </summary>
+    public string DefaultTargetLanguage { get; set; } = "de";
+
+    /// <summary>
+    /// Vector store provider: "File" or "Qdrant"
+    /// </summary>
+    public string VectorStoreProvider { get; set; } = "File";
+
+    /// <summary>
+    /// Qdrant configuration (if using Qdrant provider)
+    /// </summary>
+    public QdrantConfig Qdrant { get; set; } = new();
+}
+
+/// <summary>
+/// Ollama LLM configuration
+/// </summary>
+public class OllamaConfig
+{
+    /// <summary>
+    /// Ollama API endpoint
+    /// </summary>
+    public string Endpoint { get; set; } = "http://localhost:11434";
+
+    /// <summary>
+    /// Model name to use for translation
+    /// </summary>
+    public string Model { get; set; } = "llama3.2:3b";
+
+    /// <summary>
+    /// Temperature for generation (0.0 - 1.0)
+    /// </summary>
+    public float Temperature { get; set; } = 0.3f;
+
+    /// <summary>
+    /// Maximum tokens to generate
+    /// </summary>
+    public int MaxTokens { get; set; } = 2048;
+
+    /// <summary>
+    /// Request timeout in seconds
+    /// </summary>
+    public int TimeoutSeconds { get; set; } = 120;
+}
+
+/// <summary>
+/// NMT translator configuration
+/// </summary>
+public class NmtConfig
+{
+    /// <summary>
+    /// Enable NMT baseline translation
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// NMT service endpoints (from mostlyucid-nmt)
+    /// </summary>
+    public List<string> ServiceEndpoints { get; set; } = new() { "http://localhost:24080" };
+
+    /// <summary>
+    /// Use NMT as baseline before LLM post-editing
+    /// </summary>
+    public bool UseAsBaseline { get; set; } = true;
+}
+
+/// <summary>
+/// Embedding model configuration
+/// </summary>
+public class EmbeddingConfig
+{
+    /// <summary>
+    /// Path to the embedding model (GGUF format for LlamaSharp)
+    /// </summary>
+    public string ModelPath { get; set; } = "./models/nomic-embed-text-v1.5.Q8_0.gguf";
+
+    /// <summary>
+    /// Embedding dimension
+    /// </summary>
+    public int Dimension { get; set; } = 768;
+
+    /// <summary>
+    /// Context size for embeddings
+    /// </summary>
+    public int ContextSize { get; set; } = 2048;
+
+    /// <summary>
+    /// Batch size for embedding generation
+    /// </summary>
+    public int BatchSize { get; set; } = 512;
+}
+
+/// <summary>
+/// RAG retrieval configuration
+/// </summary>
+public class RagConfig
+{
+    /// <summary>
+    /// Number of similar blocks to retrieve
+    /// </summary>
+    public int TopK { get; set; } = 3;
+
+    /// <summary>
+    /// Always include N-1 block (sliding window)
+    /// </summary>
+    public bool UseSlidingWindow { get; set; } = true;
+
+    /// <summary>
+    /// Minimum similarity threshold (0.0 - 1.0)
+    /// </summary>
+    public float MinSimilarity { get; set; } = 0.5f;
+
+    /// <summary>
+    /// Maximum context blocks to include in prompt
+    /// </summary>
+    public int MaxContextBlocks { get; set; } = 5;
+}
+
+/// <summary>
+/// Qdrant vector database configuration
+/// </summary>
+public class QdrantConfig
+{
+    /// <summary>
+    /// Qdrant server endpoint
+    /// </summary>
+    public string Endpoint { get; set; } = "http://localhost:6333";
+
+    /// <summary>
+    /// API key for Qdrant (if required)
+    /// </summary>
+    public string? ApiKey { get; set; }
+
+    /// <summary>
+    /// Collection name for storing embeddings
+    /// </summary>
+    public string CollectionName { get; set; } = "translations";
+
+    /// <summary>
+    /// Enable HTTPS
+    /// </summary>
+    public bool UseHttps { get; set; } = false;
+}

--- a/mostlylucid.llmslidetranslator/Models/TranslationBlock.cs
+++ b/mostlylucid.llmslidetranslator/Models/TranslationBlock.cs
@@ -1,0 +1,57 @@
+namespace mostlylucid.llmslidetranslator.Models;
+
+/// <summary>
+/// Represents a block of text to be translated with its metadata
+/// </summary>
+public class TranslationBlock
+{
+    /// <summary>
+    /// Unique identifier for this block
+    /// </summary>
+    public required string BlockId { get; set; }
+
+    /// <summary>
+    /// Index/order of this block in the document
+    /// </summary>
+    public int Index { get; set; }
+
+    /// <summary>
+    /// Document identifier
+    /// </summary>
+    public required string DocumentId { get; set; }
+
+    /// <summary>
+    /// Original text content
+    /// </summary>
+    public required string Text { get; set; }
+
+    /// <summary>
+    /// Translated text content
+    /// </summary>
+    public string? TranslatedText { get; set; }
+
+    /// <summary>
+    /// Embedding vector for this block
+    /// </summary>
+    public float[]? Embedding { get; set; }
+
+    /// <summary>
+    /// Source language code
+    /// </summary>
+    public required string SourceLanguage { get; set; }
+
+    /// <summary>
+    /// Target language code
+    /// </summary>
+    public required string TargetLanguage { get; set; }
+
+    /// <summary>
+    /// Block type (e.g., paragraph, code, heading)
+    /// </summary>
+    public string BlockType { get; set; } = "paragraph";
+
+    /// <summary>
+    /// Whether this block should be translated (false for code blocks, URLs, etc.)
+    /// </summary>
+    public bool ShouldTranslate { get; set; } = true;
+}

--- a/mostlylucid.llmslidetranslator/Models/TranslationContext.cs
+++ b/mostlylucid.llmslidetranslator/Models/TranslationContext.cs
@@ -1,0 +1,32 @@
+namespace mostlylucid.llmslidetranslator.Models;
+
+/// <summary>
+/// Context information for translating a block
+/// </summary>
+public class TranslationContext
+{
+    /// <summary>
+    /// The block to translate
+    /// </summary>
+    public required TranslationBlock CurrentBlock { get; set; }
+
+    /// <summary>
+    /// Previous block (sliding window)
+    /// </summary>
+    public TranslationBlock? PreviousBlock { get; set; }
+
+    /// <summary>
+    /// Similar blocks retrieved via RAG
+    /// </summary>
+    public List<TranslationBlock> SimilarBlocks { get; set; } = new();
+
+    /// <summary>
+    /// System instructions for the LLM
+    /// </summary>
+    public string? SystemPrompt { get; set; }
+
+    /// <summary>
+    /// Additional context instructions
+    /// </summary>
+    public string? AdditionalContext { get; set; }
+}

--- a/mostlylucid.llmslidetranslator/Models/TranslationResult.cs
+++ b/mostlylucid.llmslidetranslator/Models/TranslationResult.cs
@@ -1,0 +1,140 @@
+namespace mostlylucid.llmslidetranslator.Models;
+
+/// <summary>
+/// Result of a translation operation
+/// </summary>
+public class TranslationResult
+{
+    /// <summary>
+    /// Document identifier
+    /// </summary>
+    public required string DocumentId { get; set; }
+
+    /// <summary>
+    /// Translated blocks
+    /// </summary>
+    public List<TranslationBlock> Blocks { get; set; } = new();
+
+    /// <summary>
+    /// Source language
+    /// </summary>
+    public required string SourceLanguage { get; set; }
+
+    /// <summary>
+    /// Target language
+    /// </summary>
+    public required string TargetLanguage { get; set; }
+
+    /// <summary>
+    /// Translation method used
+    /// </summary>
+    public TranslationMethod Method { get; set; }
+
+    /// <summary>
+    /// Total time taken for translation
+    /// </summary>
+    public TimeSpan Duration { get; set; }
+
+    /// <summary>
+    /// Any errors encountered
+    /// </summary>
+    public List<string> Errors { get; set; } = new();
+
+    /// <summary>
+    /// Get the full translated text by concatenating all blocks
+    /// </summary>
+    public string GetTranslatedText()
+    {
+        return string.Join("\n\n", Blocks
+            .OrderBy(b => b.Index)
+            .Select(b => b.TranslatedText ?? b.Text));
+    }
+}
+
+/// <summary>
+/// Translation method used
+/// </summary>
+public enum TranslationMethod
+{
+    /// <summary>
+    /// LLM only
+    /// </summary>
+    LlmOnly,
+
+    /// <summary>
+    /// NMT only
+    /// </summary>
+    NmtOnly,
+
+    /// <summary>
+    /// NMT baseline + LLM post-editing
+    /// </summary>
+    NmtPlusLlm,
+
+    /// <summary>
+    /// RAG-enhanced LLM
+    /// </summary>
+    RagLlm
+}
+
+/// <summary>
+/// Comparison between two translations
+/// </summary>
+public class TranslationComparison
+{
+    /// <summary>
+    /// Document identifier
+    /// </summary>
+    public required string DocumentId { get; set; }
+
+    /// <summary>
+    /// First translation result
+    /// </summary>
+    public required TranslationResult Translation1 { get; set; }
+
+    /// <summary>
+    /// Second translation result
+    /// </summary>
+    public required TranslationResult Translation2 { get; set; }
+
+    /// <summary>
+    /// Block-by-block differences
+    /// </summary>
+    public List<BlockDifference> Differences { get; set; } = new();
+
+    /// <summary>
+    /// Overall similarity score (0.0 - 1.0)
+    /// </summary>
+    public float SimilarityScore { get; set; }
+}
+
+/// <summary>
+/// Difference between two translation blocks
+/// </summary>
+public class BlockDifference
+{
+    /// <summary>
+    /// Block index
+    /// </summary>
+    public int BlockIndex { get; set; }
+
+    /// <summary>
+    /// Text from translation 1
+    /// </summary>
+    public required string Text1 { get; set; }
+
+    /// <summary>
+    /// Text from translation 2
+    /// </summary>
+    public required string Text2 { get; set; }
+
+    /// <summary>
+    /// Similarity score for this block (0.0 - 1.0)
+    /// </summary>
+    public float Similarity { get; set; }
+
+    /// <summary>
+    /// Edit distance between the two texts
+    /// </summary>
+    public int EditDistance { get; set; }
+}

--- a/mostlylucid.llmslidetranslator/README.md
+++ b/mostlylucid.llmslidetranslator/README.md
@@ -1,0 +1,175 @@
+# mostlylucid.llmslidetranslator
+
+RAG-assisted translation for long documents using small local LLMs with sliding-window chunking and vector similarity search.
+
+## Features
+
+- **RAG-Enhanced Translation**: Uses retrieval-augmented generation to maintain translation consistency across long documents
+- **Multiple Translation Methods**:
+  - RAG + LLM (recommended)
+  - LLM only
+  - NMT baseline + LLM post-editing
+  - NMT only
+- **Sliding Window Context**: Always includes the previous translated block for continuity
+- **Vector Similarity Search**: Retrieves similar earlier blocks to maintain terminology consistency
+- **Multiple Vector Store Providers**:
+  - File-based (default)
+  - Qdrant vector database
+- **Markdown-Aware Chunking**: Intelligently chunks markdown while preserving structure
+- **Real-time Progress Tracking**: SignalR support for streaming translation updates
+- **Translation Comparison**: Compare different translation methods side-by-side
+
+## Installation
+
+```bash
+dotnet add package mostlylucid.llmslidetranslator
+```
+
+## Quick Start
+
+### Basic Usage
+
+```csharp
+using mostlylucid.llmslidetranslator.Extensions;
+using mostlylucid.llmslidetranslator.Services;
+using mostlylucid.llmslidetranslator.Models;
+
+// Configure services
+builder.Services.AddLlmSlideTranslator(builder.Configuration);
+
+// Use the translator
+var translator = serviceProvider.GetRequiredService<ILlmSlideTranslator>();
+
+var result = await translator.TranslateAsync(
+    markdown: "# My Document\n\nThis is a long technical document...",
+    documentId: "doc_001",
+    sourceLanguage: "en",
+    targetLanguage: "de",
+    method: TranslationMethod.RagLlm
+);
+
+Console.WriteLine(result.GetTranslatedText());
+```
+
+### Configuration
+
+Add to `appsettings.json`:
+
+```json
+{
+  "LlmSlideTranslator": {
+    "Ollama": {
+      "Endpoint": "http://localhost:11434",
+      "Model": "llama3.2:3b",
+      "Temperature": 0.3
+    },
+    "Nmt": {
+      "Enabled": true,
+      "ServiceEndpoints": ["http://localhost:24080"],
+      "UseAsBaseline": true
+    },
+    "Embedding": {
+      "ModelPath": "./models/nomic-embed-text-v1.5.Q8_0.gguf",
+      "Dimension": 768
+    },
+    "Rag": {
+      "TopK": 3,
+      "UseSlidingWindow": true,
+      "MinSimilarity": 0.5
+    },
+    "VectorStoreProvider": "File",
+    "DataPath": "./data"
+  }
+}
+```
+
+### Using Qdrant
+
+To use Qdrant instead of file-based storage:
+
+```json
+{
+  "LlmSlideTranslator": {
+    "VectorStoreProvider": "Qdrant",
+    "Qdrant": {
+      "Endpoint": "http://localhost:6333",
+      "CollectionName": "translations"
+    }
+  }
+}
+```
+
+### Translation Methods
+
+```csharp
+// RAG-enhanced LLM (best quality, maintains consistency)
+await translator.TranslateAsync(..., method: TranslationMethod.RagLlm);
+
+// NMT baseline + LLM post-editing (good balance)
+await translator.TranslateAsync(..., method: TranslationMethod.NmtPlusLlm);
+
+// LLM only (creative, but may drift)
+await translator.TranslateAsync(..., method: TranslationMethod.LlmOnly);
+
+// NMT only (fast, baseline quality)
+await translator.TranslateAsync(..., method: TranslationMethod.NmtOnly);
+```
+
+### Comparing Translations
+
+```csharp
+var comparer = serviceProvider.GetRequiredService<ITranslationComparer>();
+
+var comparison = await comparer.CompareAsync(result1, result2);
+
+Console.WriteLine($"Overall similarity: {comparison.SimilarityScore:P}");
+
+foreach (var diff in comparison.Differences)
+{
+    Console.WriteLine($"Block {diff.BlockIndex}: {diff.Similarity:P} similar");
+}
+```
+
+## Requirements
+
+- .NET 9.0 or later
+- Ollama running locally with a model (e.g., llama3.2:3b)
+- Embedding model in GGUF format (e.g., nomic-embed-text-v1.5)
+- Optional: NMT service from [mostlyucid-nmt](https://github.com/scottgal/mostlyucid-nmt)
+- Optional: Qdrant vector database
+
+## How It Works
+
+1. **Chunking**: Markdown is split into translatable blocks (paragraphs, headings, lists)
+2. **Embedding**: Each block is converted to a vector embedding
+3. **Storage**: Blocks and embeddings are stored in a vector database
+4. **Translation Loop**: For each block:
+   - Generate embedding for current block
+   - Retrieve most similar earlier blocks (RAG)
+   - Include previous block (sliding window)
+   - Build context-aware prompt
+   - Translate with LLM
+5. **Output**: Aligned block-by-block translation
+
+## Demo API
+
+See the `mostlylucid.llmslidetranslator.Demo` project for a complete example with:
+- ASP.NET Minimal API endpoints
+- SignalR hub for real-time updates
+- Streaming translation endpoint (SSE)
+- Translation comparison
+
+```bash
+cd mostlylucid.llmslidetranslator.Demo
+dotnet run
+```
+
+Then navigate to `http://localhost:5000/swagger` for the API documentation.
+
+## License
+
+Unlicense - Public Domain
+
+## Contributing
+
+Contributions welcome! Please open an issue or PR on GitHub.

--- a/mostlylucid.llmslidetranslator/Services/EmbeddingGenerator.cs
+++ b/mostlylucid.llmslidetranslator/Services/EmbeddingGenerator.cs
@@ -1,0 +1,147 @@
+using LLama;
+using LLama.Common;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using mostlylucid.llmslidetranslator.Models;
+
+namespace mostlylucid.llmslidetranslator.Services;
+
+/// <summary>
+/// Generates embeddings using LlamaSharp
+/// </summary>
+public class EmbeddingGenerator : IEmbeddingGenerator, IDisposable
+{
+    private readonly ILogger<EmbeddingGenerator> _logger;
+    private readonly LlmSlideTranslatorConfig _config;
+    private LLamaEmbedder? _embedder;
+    private readonly SemaphoreSlim _initLock = new(1, 1);
+    private bool _initialized = false;
+
+    public EmbeddingGenerator(
+        ILogger<EmbeddingGenerator> logger,
+        IOptions<LlmSlideTranslatorConfig> config)
+    {
+        _logger = logger;
+        _config = config.Value;
+    }
+
+    private async Task EnsureInitializedAsync()
+    {
+        if (_initialized)
+            return;
+
+        await _initLock.WaitAsync();
+        try
+        {
+            if (_initialized)
+                return;
+
+            _logger.LogInformation("Initializing embedding model from {ModelPath}",
+                _config.Embedding.ModelPath);
+
+            if (!File.Exists(_config.Embedding.ModelPath))
+            {
+                throw new FileNotFoundException(
+                    $"Embedding model not found at {_config.Embedding.ModelPath}. " +
+                    "Please download a GGUF embedding model (e.g., nomic-embed-text).");
+            }
+
+            var parameters = new ModelParams(_config.Embedding.ModelPath)
+            {
+                ContextSize = (uint)_config.Embedding.ContextSize,
+                Embeddings = true,
+                GpuLayerCount = 0  // Use CPU for embeddings
+            };
+
+            var weights = LLamaWeights.LoadFromFile(parameters);
+            _embedder = new LLamaEmbedder(weights, parameters);
+
+            _initialized = true;
+            _logger.LogInformation("Embedding model initialized successfully");
+        }
+        finally
+        {
+            _initLock.Release();
+        }
+    }
+
+    public async Task<float[]> GenerateEmbeddingAsync(string text, CancellationToken cancellationToken = default)
+    {
+        await EnsureInitializedAsync();
+
+        if (_embedder == null)
+        {
+            throw new InvalidOperationException("Embedder not initialized");
+        }
+
+        _logger.LogDebug("Generating embedding for text of length {Length}", text.Length);
+
+        try
+        {
+            var embedding = await Task.Run(() => _embedder.GetEmbeddings(text), cancellationToken);
+            return embedding;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error generating embedding");
+            throw;
+        }
+    }
+
+    public async Task<List<TranslationBlock>> GenerateEmbeddingsAsync(
+        List<TranslationBlock> blocks,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureInitializedAsync();
+
+        _logger.LogInformation("Generating embeddings for {Count} blocks", blocks.Count);
+
+        var tasks = blocks.Select(async block =>
+        {
+            if (block.ShouldTranslate)
+            {
+                block.Embedding = await GenerateEmbeddingAsync(block.Text, cancellationToken);
+            }
+            return block;
+        });
+
+        var results = await Task.WhenAll(tasks);
+        return results.ToList();
+    }
+
+    public float CalculateSimilarity(float[] embedding1, float[] embedding2)
+    {
+        if (embedding1.Length != embedding2.Length)
+        {
+            throw new ArgumentException("Embeddings must have the same dimension");
+        }
+
+        // Calculate cosine similarity
+        var dotProduct = 0.0f;
+        var magnitude1 = 0.0f;
+        var magnitude2 = 0.0f;
+
+        for (int i = 0; i < embedding1.Length; i++)
+        {
+            dotProduct += embedding1[i] * embedding2[i];
+            magnitude1 += embedding1[i] * embedding1[i];
+            magnitude2 += embedding2[i] * embedding2[i];
+        }
+
+        magnitude1 = MathF.Sqrt(magnitude1);
+        magnitude2 = MathF.Sqrt(magnitude2);
+
+        if (magnitude1 == 0 || magnitude2 == 0)
+        {
+            return 0;
+        }
+
+        return dotProduct / (magnitude1 * magnitude2);
+    }
+
+    public void Dispose()
+    {
+        _embedder?.Dispose();
+        _initLock.Dispose();
+    }
+}

--- a/mostlylucid.llmslidetranslator/Services/FileVectorStore.cs
+++ b/mostlylucid.llmslidetranslator/Services/FileVectorStore.cs
@@ -1,0 +1,142 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using mostlylucid.llmslidetranslator.Models;
+
+namespace mostlylucid.llmslidetranslator.Services;
+
+/// <summary>
+/// File-based vector store for embeddings
+/// </summary>
+public class FileVectorStore : IVectorStore
+{
+    private readonly ILogger<FileVectorStore> _logger;
+    private readonly IEmbeddingGenerator _embeddingGenerator;
+    private readonly string _dataPath;
+    private readonly SemaphoreSlim _fileLock = new(1, 1);
+
+    public FileVectorStore(
+        ILogger<FileVectorStore> logger,
+        IEmbeddingGenerator embeddingGenerator,
+        IOptions<LlmSlideTranslatorConfig> config)
+    {
+        _logger = logger;
+        _embeddingGenerator = embeddingGenerator;
+        _dataPath = config.Value.DataPath;
+
+        // Ensure data directory exists
+        Directory.CreateDirectory(_dataPath);
+    }
+
+    public async Task StoreAsync(
+        List<TranslationBlock> blocks,
+        string documentId,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("Storing {Count} blocks for document {DocumentId}",
+            blocks.Count, documentId);
+
+        var filePath = GetDocumentPath(documentId);
+
+        await _fileLock.WaitAsync(cancellationToken);
+        try
+        {
+            var json = JsonSerializer.Serialize(blocks, new JsonSerializerOptions
+            {
+                WriteIndented = true
+            });
+
+            await File.WriteAllTextAsync(filePath, json, cancellationToken);
+
+            _logger.LogInformation("Stored blocks to {FilePath}", filePath);
+        }
+        finally
+        {
+            _fileLock.Release();
+        }
+    }
+
+    public async Task<List<(TranslationBlock Block, float Similarity)>> SearchAsync(
+        float[] queryEmbedding,
+        string documentId,
+        int topK,
+        float minSimilarity = 0.0f,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug("Searching for top {TopK} similar blocks in document {DocumentId}",
+            topK, documentId);
+
+        var blocks = await GetDocumentBlocksAsync(documentId, cancellationToken);
+
+        var results = blocks
+            .Where(b => b.Embedding != null)
+            .Select(b => new
+            {
+                Block = b,
+                Similarity = _embeddingGenerator.CalculateSimilarity(queryEmbedding, b.Embedding!)
+            })
+            .Where(r => r.Similarity >= minSimilarity)
+            .OrderByDescending(r => r.Similarity)
+            .Take(topK)
+            .Select(r => (r.Block, r.Similarity))
+            .ToList();
+
+        _logger.LogDebug("Found {Count} similar blocks above threshold {MinSimilarity}",
+            results.Count, minSimilarity);
+
+        return results;
+    }
+
+    public async Task<List<TranslationBlock>> GetDocumentBlocksAsync(
+        string documentId,
+        CancellationToken cancellationToken = default)
+    {
+        var filePath = GetDocumentPath(documentId);
+
+        if (!File.Exists(filePath))
+        {
+            _logger.LogWarning("Document {DocumentId} not found at {FilePath}",
+                documentId, filePath);
+            return new List<TranslationBlock>();
+        }
+
+        await _fileLock.WaitAsync(cancellationToken);
+        try
+        {
+            var json = await File.ReadAllTextAsync(filePath, cancellationToken);
+            var blocks = JsonSerializer.Deserialize<List<TranslationBlock>>(json);
+
+            return blocks ?? new List<TranslationBlock>();
+        }
+        finally
+        {
+            _fileLock.Release();
+        }
+    }
+
+    public async Task ClearDocumentAsync(string documentId, CancellationToken cancellationToken = default)
+    {
+        var filePath = GetDocumentPath(documentId);
+
+        if (File.Exists(filePath))
+        {
+            await _fileLock.WaitAsync(cancellationToken);
+            try
+            {
+                File.Delete(filePath);
+                _logger.LogInformation("Cleared document {DocumentId}", documentId);
+            }
+            finally
+            {
+                _fileLock.Release();
+            }
+        }
+    }
+
+    private string GetDocumentPath(string documentId)
+    {
+        // Sanitize document ID for use as filename
+        var safeDocId = string.Join("_", documentId.Split(Path.GetInvalidFileNameChars()));
+        return Path.Combine(_dataPath, $"{safeDocId}.json");
+    }
+}

--- a/mostlylucid.llmslidetranslator/Services/IEmbeddingGenerator.cs
+++ b/mostlylucid.llmslidetranslator/Services/IEmbeddingGenerator.cs
@@ -1,0 +1,35 @@
+using mostlylucid.llmslidetranslator.Models;
+
+namespace mostlylucid.llmslidetranslator.Services;
+
+/// <summary>
+/// Generates embeddings for text blocks
+/// </summary>
+public interface IEmbeddingGenerator
+{
+    /// <summary>
+    /// Generate embedding for a single block
+    /// </summary>
+    /// <param name="text">Text to embed</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Embedding vector</returns>
+    Task<float[]> GenerateEmbeddingAsync(string text, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Generate embeddings for multiple blocks
+    /// </summary>
+    /// <param name="blocks">Blocks to embed</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Blocks with embeddings populated</returns>
+    Task<List<TranslationBlock>> GenerateEmbeddingsAsync(
+        List<TranslationBlock> blocks,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Calculate cosine similarity between two embeddings
+    /// </summary>
+    /// <param name="embedding1">First embedding</param>
+    /// <param name="embedding2">Second embedding</param>
+    /// <returns>Similarity score (0.0 - 1.0)</returns>
+    float CalculateSimilarity(float[] embedding1, float[] embedding2);
+}

--- a/mostlylucid.llmslidetranslator/Services/ILlmSlideTranslator.cs
+++ b/mostlylucid.llmslidetranslator/Services/ILlmSlideTranslator.cs
@@ -1,0 +1,85 @@
+using mostlylucid.llmslidetranslator.Models;
+
+namespace mostlylucid.llmslidetranslator.Services;
+
+/// <summary>
+/// Main translation service orchestrating RAG-assisted LLM translation
+/// </summary>
+public interface ILlmSlideTranslator
+{
+    /// <summary>
+    /// Translate a markdown document using RAG-assisted LLM
+    /// </summary>
+    /// <param name="markdown">Markdown content</param>
+    /// <param name="documentId">Document identifier</param>
+    /// <param name="sourceLanguage">Source language code</param>
+    /// <param name="targetLanguage">Target language code</param>
+    /// <param name="method">Translation method to use</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Translation result</returns>
+    Task<TranslationResult> TranslateAsync(
+        string markdown,
+        string documentId,
+        string sourceLanguage,
+        string targetLanguage,
+        TranslationMethod method = TranslationMethod.RagLlm,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Translate a single block with RAG context
+    /// </summary>
+    /// <param name="block">Block to translate</param>
+    /// <param name="previousBlock">Previous block (sliding window)</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Translated block</returns>
+    Task<TranslationBlock> TranslateBlockAsync(
+        TranslationBlock block,
+        TranslationBlock? previousBlock = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Get translation progress for a document
+    /// </summary>
+    /// <param name="documentId">Document identifier</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Progress information</returns>
+    Task<TranslationProgress> GetProgressAsync(
+        string documentId,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Translation progress information
+/// </summary>
+public class TranslationProgress
+{
+    /// <summary>
+    /// Document identifier
+    /// </summary>
+    public required string DocumentId { get; set; }
+
+    /// <summary>
+    /// Total number of blocks
+    /// </summary>
+    public int TotalBlocks { get; set; }
+
+    /// <summary>
+    /// Number of blocks translated
+    /// </summary>
+    public int TranslatedBlocks { get; set; }
+
+    /// <summary>
+    /// Percentage complete (0-100)
+    /// </summary>
+    public float PercentComplete => TotalBlocks > 0 ? (float)TranslatedBlocks / TotalBlocks * 100 : 0;
+
+    /// <summary>
+    /// Current block being translated
+    /// </summary>
+    public int? CurrentBlockIndex { get; set; }
+
+    /// <summary>
+    /// Estimated time remaining
+    /// </summary>
+    public TimeSpan? EstimatedTimeRemaining { get; set; }
+}

--- a/mostlylucid.llmslidetranslator/Services/IMarkdownChunker.cs
+++ b/mostlylucid.llmslidetranslator/Services/IMarkdownChunker.cs
@@ -1,0 +1,25 @@
+using mostlylucid.llmslidetranslator.Models;
+
+namespace mostlylucid.llmslidetranslator.Services;
+
+/// <summary>
+/// Chunks markdown documents into translatable blocks
+/// </summary>
+public interface IMarkdownChunker
+{
+    /// <summary>
+    /// Chunk a markdown document into translation blocks
+    /// </summary>
+    /// <param name="markdown">Markdown content</param>
+    /// <param name="documentId">Document identifier</param>
+    /// <param name="sourceLanguage">Source language code</param>
+    /// <param name="targetLanguage">Target language code</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>List of translation blocks</returns>
+    Task<List<TranslationBlock>> ChunkAsync(
+        string markdown,
+        string documentId,
+        string sourceLanguage,
+        string targetLanguage,
+        CancellationToken cancellationToken = default);
+}

--- a/mostlylucid.llmslidetranslator/Services/INmtClient.cs
+++ b/mostlylucid.llmslidetranslator/Services/INmtClient.cs
@@ -1,0 +1,41 @@
+using mostlylucid.llmslidetranslator.Models;
+
+namespace mostlylucid.llmslidetranslator.Services;
+
+/// <summary>
+/// Client for NMT (Neural Machine Translation) service
+/// Based on https://github.com/scottgal/mostlyucid-nmt (Opus-MT)
+/// </summary>
+public interface INmtClient
+{
+    /// <summary>
+    /// Translate text using NMT
+    /// </summary>
+    /// <param name="text">Text to translate</param>
+    /// <param name="sourceLanguage">Source language code</param>
+    /// <param name="targetLanguage">Target language code</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Translated text</returns>
+    Task<string> TranslateAsync(
+        string text,
+        string sourceLanguage,
+        string targetLanguage,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Translate multiple blocks using NMT
+    /// </summary>
+    /// <param name="blocks">Blocks to translate</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Blocks with translations</returns>
+    Task<List<TranslationBlock>> TranslateBatchAsync(
+        List<TranslationBlock> blocks,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Check if NMT service is available
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>True if available</returns>
+    Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default);
+}

--- a/mostlylucid.llmslidetranslator/Services/IOllamaClient.cs
+++ b/mostlylucid.llmslidetranslator/Services/IOllamaClient.cs
@@ -1,0 +1,33 @@
+using mostlylucid.llmslidetranslator.Models;
+
+namespace mostlylucid.llmslidetranslator.Services;
+
+/// <summary>
+/// Client for Ollama LLM API
+/// </summary>
+public interface IOllamaClient
+{
+    /// <summary>
+    /// Translate a block using the LLM with context
+    /// </summary>
+    /// <param name="context">Translation context with current block and RAG context</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Translated text</returns>
+    Task<string> TranslateWithContextAsync(
+        TranslationContext context,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Check if Ollama service is available
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>True if available</returns>
+    Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Get list of available models
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>List of model names</returns>
+    Task<List<string>> GetModelsAsync(CancellationToken cancellationToken = default);
+}

--- a/mostlylucid.llmslidetranslator/Services/ITranslationComparer.cs
+++ b/mostlylucid.llmslidetranslator/Services/ITranslationComparer.cs
@@ -1,0 +1,37 @@
+using mostlylucid.llmslidetranslator.Models;
+
+namespace mostlylucid.llmslidetranslator.Services;
+
+/// <summary>
+/// Service for comparing translations
+/// </summary>
+public interface ITranslationComparer
+{
+    /// <summary>
+    /// Compare two translation results
+    /// </summary>
+    /// <param name="result1">First translation result</param>
+    /// <param name="result2">Second translation result</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Comparison result</returns>
+    Task<TranslationComparison> CompareAsync(
+        TranslationResult result1,
+        TranslationResult result2,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Calculate Levenshtein edit distance between two strings
+    /// </summary>
+    /// <param name="text1">First text</param>
+    /// <param name="text2">Second text</param>
+    /// <returns>Edit distance</returns>
+    int CalculateEditDistance(string text1, string text2);
+
+    /// <summary>
+    /// Calculate BLEU score between reference and candidate translation
+    /// </summary>
+    /// <param name="reference">Reference translation</param>
+    /// <param name="candidate">Candidate translation</param>
+    /// <returns>BLEU score (0.0 - 1.0)</returns>
+    float CalculateBleuScore(string reference, string candidate);
+}

--- a/mostlylucid.llmslidetranslator/Services/IVectorStore.cs
+++ b/mostlylucid.llmslidetranslator/Services/IVectorStore.cs
@@ -1,0 +1,50 @@
+using mostlylucid.llmslidetranslator.Models;
+
+namespace mostlylucid.llmslidetranslator.Services;
+
+/// <summary>
+/// File-based vector store for embeddings
+/// </summary>
+public interface IVectorStore
+{
+    /// <summary>
+    /// Store translation blocks with embeddings
+    /// </summary>
+    /// <param name="blocks">Blocks to store</param>
+    /// <param name="documentId">Document identifier</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    Task StoreAsync(List<TranslationBlock> blocks, string documentId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Search for similar blocks using vector similarity
+    /// </summary>
+    /// <param name="queryEmbedding">Query embedding vector</param>
+    /// <param name="documentId">Document identifier to search within</param>
+    /// <param name="topK">Number of results to return</param>
+    /// <param name="minSimilarity">Minimum similarity threshold</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>List of similar blocks with similarity scores</returns>
+    Task<List<(TranslationBlock Block, float Similarity)>> SearchAsync(
+        float[] queryEmbedding,
+        string documentId,
+        int topK,
+        float minSimilarity = 0.0f,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Get all blocks for a document
+    /// </summary>
+    /// <param name="documentId">Document identifier</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>List of blocks</returns>
+    Task<List<TranslationBlock>> GetDocumentBlocksAsync(
+        string documentId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Clear all data for a document
+    /// </summary>
+    /// <param name="documentId">Document identifier</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    Task ClearDocumentAsync(string documentId, CancellationToken cancellationToken = default);
+}

--- a/mostlylucid.llmslidetranslator/Services/LlmSlideTranslator.cs
+++ b/mostlylucid.llmslidetranslator/Services/LlmSlideTranslator.cs
@@ -1,0 +1,248 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using mostlylucid.llmslidetranslator.Models;
+
+namespace mostlylucid.llmslidetranslator.Services;
+
+/// <summary>
+/// Main translation service orchestrating RAG-assisted LLM translation
+/// </summary>
+public class LlmSlideTranslator : ILlmSlideTranslator
+{
+    private readonly ILogger<LlmSlideTranslator> _logger;
+    private readonly IMarkdownChunker _chunker;
+    private readonly IEmbeddingGenerator _embeddingGenerator;
+    private readonly IVectorStore _vectorStore;
+    private readonly IOllamaClient _ollamaClient;
+    private readonly INmtClient _nmtClient;
+    private readonly LlmSlideTranslatorConfig _config;
+
+    public LlmSlideTranslator(
+        ILogger<LlmSlideTranslator> logger,
+        IMarkdownChunker chunker,
+        IEmbeddingGenerator embeddingGenerator,
+        IVectorStore vectorStore,
+        IOllamaClient ollamaClient,
+        INmtClient nmtClient,
+        IOptions<LlmSlideTranslatorConfig> config)
+    {
+        _logger = logger;
+        _chunker = chunker;
+        _embeddingGenerator = embeddingGenerator;
+        _vectorStore = vectorStore;
+        _ollamaClient = ollamaClient;
+        _nmtClient = nmtClient;
+        _config = config.Value;
+    }
+
+    public async Task<TranslationResult> TranslateAsync(
+        string markdown,
+        string documentId,
+        string sourceLanguage,
+        string targetLanguage,
+        TranslationMethod method = TranslationMethod.RagLlm,
+        CancellationToken cancellationToken = default)
+    {
+        var stopwatch = Stopwatch.StartNew();
+
+        _logger.LogInformation(
+            "Starting translation of document {DocumentId} from {Source} to {Target} using {Method}",
+            documentId, sourceLanguage, targetLanguage, method);
+
+        var result = new TranslationResult
+        {
+            DocumentId = documentId,
+            SourceLanguage = sourceLanguage,
+            TargetLanguage = targetLanguage,
+            Method = method
+        };
+
+        try
+        {
+            // Step 1: Chunk the markdown
+            var blocks = await _chunker.ChunkAsync(
+                markdown,
+                documentId,
+                sourceLanguage,
+                targetLanguage,
+                cancellationToken);
+
+            _logger.LogInformation("Chunked document into {Count} blocks", blocks.Count);
+
+            // Step 2: Generate embeddings
+            blocks = await _embeddingGenerator.GenerateEmbeddingsAsync(blocks, cancellationToken);
+            _logger.LogInformation("Generated embeddings for all blocks");
+
+            // Step 3: Store blocks with embeddings
+            await _vectorStore.StoreAsync(blocks, documentId, cancellationToken);
+
+            // Step 4: Translate based on method
+            switch (method)
+            {
+                case TranslationMethod.NmtOnly:
+                    blocks = await TranslateWithNmtOnlyAsync(blocks, cancellationToken);
+                    break;
+
+                case TranslationMethod.LlmOnly:
+                    blocks = await TranslateWithLlmOnlyAsync(blocks, cancellationToken);
+                    break;
+
+                case TranslationMethod.NmtPlusLlm:
+                    blocks = await TranslateWithNmtPlusLlmAsync(blocks, cancellationToken);
+                    break;
+
+                case TranslationMethod.RagLlm:
+                default:
+                    blocks = await TranslateWithRagLlmAsync(blocks, cancellationToken);
+                    break;
+            }
+
+            // Step 5: Update stored blocks with translations
+            await _vectorStore.StoreAsync(blocks, documentId, cancellationToken);
+
+            result.Blocks = blocks;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error translating document {DocumentId}", documentId);
+            result.Errors.Add(ex.Message);
+        }
+
+        stopwatch.Stop();
+        result.Duration = stopwatch.Elapsed;
+
+        _logger.LogInformation(
+            "Translation completed in {Duration:F2}s for document {DocumentId}",
+            result.Duration.TotalSeconds, documentId);
+
+        return result;
+    }
+
+    public async Task<TranslationBlock> TranslateBlockAsync(
+        TranslationBlock block,
+        TranslationBlock? previousBlock = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (!block.ShouldTranslate)
+        {
+            block.TranslatedText = block.Text;
+            return block;
+        }
+
+        // Get RAG context
+        var similarBlocks = new List<TranslationBlock>();
+        if (block.Embedding != null)
+        {
+            var searchResults = await _vectorStore.SearchAsync(
+                block.Embedding,
+                block.DocumentId,
+                _config.Rag.TopK,
+                _config.Rag.MinSimilarity,
+                cancellationToken);
+
+            similarBlocks = searchResults
+                .Where(r => r.Block.Index < block.Index) // Only use earlier blocks
+                .Select(r => r.Block)
+                .ToList();
+        }
+
+        // Build translation context
+        var context = new TranslationContext
+        {
+            CurrentBlock = block,
+            PreviousBlock = _config.Rag.UseSlidingWindow ? previousBlock : null,
+            SimilarBlocks = similarBlocks.Take(_config.Rag.MaxContextBlocks).ToList()
+        };
+
+        // Translate with LLM
+        var translatedText = await _ollamaClient.TranslateWithContextAsync(context, cancellationToken);
+        block.TranslatedText = translatedText;
+
+        return block;
+    }
+
+    public async Task<TranslationProgress> GetProgressAsync(
+        string documentId,
+        CancellationToken cancellationToken = default)
+    {
+        var blocks = await _vectorStore.GetDocumentBlocksAsync(documentId, cancellationToken);
+
+        var translatedCount = blocks.Count(b => !string.IsNullOrEmpty(b.TranslatedText));
+
+        return new TranslationProgress
+        {
+            DocumentId = documentId,
+            TotalBlocks = blocks.Count,
+            TranslatedBlocks = translatedCount
+        };
+    }
+
+    private async Task<List<TranslationBlock>> TranslateWithNmtOnlyAsync(
+        List<TranslationBlock> blocks,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Translating with NMT only");
+        return await _nmtClient.TranslateBatchAsync(blocks, cancellationToken);
+    }
+
+    private async Task<List<TranslationBlock>> TranslateWithLlmOnlyAsync(
+        List<TranslationBlock> blocks,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Translating with LLM only (no RAG)");
+
+        TranslationBlock? previousBlock = null;
+
+        foreach (var block in blocks.OrderBy(b => b.Index))
+        {
+            if (!block.ShouldTranslate)
+            {
+                block.TranslatedText = block.Text;
+                previousBlock = block;
+                continue;
+            }
+
+            var context = new TranslationContext
+            {
+                CurrentBlock = block,
+                PreviousBlock = previousBlock
+            };
+
+            block.TranslatedText = await _ollamaClient.TranslateWithContextAsync(context, cancellationToken);
+            previousBlock = block;
+        }
+
+        return blocks;
+    }
+
+    private async Task<List<TranslationBlock>> TranslateWithNmtPlusLlmAsync(
+        List<TranslationBlock> blocks,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Translating with NMT + LLM post-editing");
+
+        // First pass: NMT baseline
+        blocks = await _nmtClient.TranslateBatchAsync(blocks, cancellationToken);
+
+        // Second pass: LLM post-editing with RAG
+        return await TranslateWithRagLlmAsync(blocks, cancellationToken);
+    }
+
+    private async Task<List<TranslationBlock>> TranslateWithRagLlmAsync(
+        List<TranslationBlock> blocks,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Translating with RAG-enhanced LLM");
+
+        TranslationBlock? previousBlock = null;
+
+        foreach (var block in blocks.OrderBy(b => b.Index))
+        {
+            await TranslateBlockAsync(block, previousBlock, cancellationToken);
+            previousBlock = block;
+        }
+
+        return blocks;
+    }
+}

--- a/mostlylucid.llmslidetranslator/Services/MarkdownChunker.cs
+++ b/mostlylucid.llmslidetranslator/Services/MarkdownChunker.cs
@@ -1,0 +1,146 @@
+using Markdig;
+using Markdig.Syntax;
+using Markdig.Syntax.Inlines;
+using Microsoft.Extensions.Logging;
+using mostlylucid.llmslidetranslator.Models;
+
+namespace mostlylucid.llmslidetranslator.Services;
+
+/// <summary>
+/// Chunks markdown documents into translatable blocks
+/// </summary>
+public class MarkdownChunker : IMarkdownChunker
+{
+    private readonly ILogger<MarkdownChunker> _logger;
+    private readonly MarkdownPipeline _pipeline;
+
+    public MarkdownChunker(ILogger<MarkdownChunker> logger)
+    {
+        _logger = logger;
+        _pipeline = new MarkdownPipelineBuilder()
+            .UseAdvancedExtensions()
+            .Build();
+    }
+
+    public Task<List<TranslationBlock>> ChunkAsync(
+        string markdown,
+        string documentId,
+        string sourceLanguage,
+        string targetLanguage,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("Chunking markdown document {DocumentId}", documentId);
+
+        var document = Markdown.Parse(markdown, _pipeline);
+        var blocks = new List<TranslationBlock>();
+        var index = 0;
+
+        foreach (var block in document)
+        {
+            var translationBlock = CreateTranslationBlock(
+                block,
+                documentId,
+                sourceLanguage,
+                targetLanguage,
+                index);
+
+            if (translationBlock != null)
+            {
+                blocks.Add(translationBlock);
+                index++;
+            }
+        }
+
+        _logger.LogInformation("Created {Count} translation blocks from document {DocumentId}",
+            blocks.Count, documentId);
+
+        return Task.FromResult(blocks);
+    }
+
+    private TranslationBlock? CreateTranslationBlock(
+        Block block,
+        string documentId,
+        string sourceLanguage,
+        string targetLanguage,
+        int index)
+    {
+        var text = ExtractText(block);
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return null;
+        }
+
+        var blockType = DetermineBlockType(block);
+        var shouldTranslate = ShouldTranslateBlock(block, blockType);
+
+        return new TranslationBlock
+        {
+            BlockId = $"{documentId}_{index}",
+            Index = index,
+            DocumentId = documentId,
+            Text = text.Trim(),
+            SourceLanguage = sourceLanguage,
+            TargetLanguage = targetLanguage,
+            BlockType = blockType,
+            ShouldTranslate = shouldTranslate
+        };
+    }
+
+    private string ExtractText(Block block)
+    {
+        return block switch
+        {
+            LeafBlock leafBlock => leafBlock.Lines.ToString(),
+            ContainerBlock containerBlock => string.Join("\n",
+                containerBlock.SelectMany(b => b is LeafBlock lb
+                    ? new[] { lb.Lines.ToString() }
+                    : Array.Empty<string>())),
+            _ => string.Empty
+        };
+    }
+
+    private string DetermineBlockType(Block block)
+    {
+        return block switch
+        {
+            HeadingBlock => "heading",
+            CodeBlock => "code",
+            FencedCodeBlock => "code",
+            QuoteBlock => "quote",
+            ListBlock => "list",
+            ParagraphBlock => "paragraph",
+            _ => "other"
+        };
+    }
+
+    private bool ShouldTranslateBlock(Block block, string blockType)
+    {
+        // Don't translate code blocks
+        if (blockType == "code")
+        {
+            return false;
+        }
+
+        // Don't translate blocks that are primarily URLs or code
+        if (block is ParagraphBlock paragraph)
+        {
+            var text = ExtractText(block);
+
+            // Check if it's mostly a URL
+            if (text.StartsWith("http://") || text.StartsWith("https://"))
+            {
+                return false;
+            }
+
+            // Check if it contains inline code
+            var hasInlineCode = paragraph.Inline?.Any(inline => inline is CodeInline) ?? false;
+            if (hasInlineCode && text.Length < 100)
+            {
+                // Short blocks with code snippets might be better left untranslated
+                _logger.LogDebug("Skipping translation of short code-heavy block");
+            }
+        }
+
+        return true;
+    }
+}

--- a/mostlylucid.llmslidetranslator/Services/NmtClient.cs
+++ b/mostlylucid.llmslidetranslator/Services/NmtClient.cs
@@ -1,0 +1,157 @@
+using System.Net.Http.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using mostlylucid.llmslidetranslator.Models;
+
+namespace mostlylucid.llmslidetranslator.Services;
+
+/// <summary>
+/// Client for NMT (Neural Machine Translation) service
+/// Based on https://github.com/scottgal/mostlyucid-nmt (Opus-MT)
+/// </summary>
+public class NmtClient : INmtClient
+{
+    private readonly ILogger<NmtClient> _logger;
+    private readonly HttpClient _httpClient;
+    private readonly LlmSlideTranslatorConfig _config;
+    private int _currentEndpointIndex = 0;
+    private readonly object _endpointLock = new();
+
+    public NmtClient(
+        ILogger<NmtClient> logger,
+        HttpClient httpClient,
+        IOptions<LlmSlideTranslatorConfig> config)
+    {
+        _logger = logger;
+        _httpClient = httpClient;
+        _config = config.Value;
+    }
+
+    public async Task<string> TranslateAsync(
+        string text,
+        string sourceLanguage,
+        string targetLanguage,
+        CancellationToken cancellationToken = default)
+    {
+        if (!_config.Nmt.Enabled)
+        {
+            throw new InvalidOperationException("NMT is not enabled in configuration");
+        }
+
+        _logger.LogDebug("Translating text from {Source} to {Target} using NMT",
+            sourceLanguage, targetLanguage);
+
+        var endpoint = GetNextEndpoint();
+
+        var requestBody = new
+        {
+            text,
+            source_lang = sourceLanguage,
+            target_lang = targetLanguage
+        };
+
+        try
+        {
+            var response = await _httpClient.PostAsJsonAsync(
+                $"{endpoint}/translate",
+                requestBody,
+                cancellationToken);
+
+            response.EnsureSuccessStatusCode();
+
+            var result = await response.Content.ReadFromJsonAsync<NmtResponse>(
+                cancellationToken: cancellationToken);
+
+            if (result?.TranslatedText == null)
+            {
+                throw new InvalidOperationException("NMT returned null translation");
+            }
+
+            return result.TranslatedText;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error translating with NMT at endpoint {Endpoint}", endpoint);
+            throw;
+        }
+    }
+
+    public async Task<List<TranslationBlock>> TranslateBatchAsync(
+        List<TranslationBlock> blocks,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("Translating {Count} blocks with NMT", blocks.Count);
+
+        var translatedBlocks = new List<TranslationBlock>();
+
+        foreach (var block in blocks)
+        {
+            if (!block.ShouldTranslate)
+            {
+                translatedBlocks.Add(block);
+                continue;
+            }
+
+            try
+            {
+                var translatedText = await TranslateAsync(
+                    block.Text,
+                    block.SourceLanguage,
+                    block.TargetLanguage,
+                    cancellationToken);
+
+                block.TranslatedText = translatedText;
+                translatedBlocks.Add(block);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error translating block {BlockId}", block.BlockId);
+                // Keep original text if translation fails
+                block.TranslatedText = block.Text;
+                translatedBlocks.Add(block);
+            }
+        }
+
+        return translatedBlocks;
+    }
+
+    public async Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default)
+    {
+        if (!_config.Nmt.Enabled || _config.Nmt.ServiceEndpoints.Count == 0)
+        {
+            return false;
+        }
+
+        try
+        {
+            var endpoint = _config.Nmt.ServiceEndpoints[0];
+            var response = await _httpClient.GetAsync($"{endpoint}/health", cancellationToken);
+            return response.IsSuccessStatusCode;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "NMT service not available");
+            return false;
+        }
+    }
+
+    private string GetNextEndpoint()
+    {
+        if (_config.Nmt.ServiceEndpoints.Count == 0)
+        {
+            throw new InvalidOperationException("No NMT service endpoints configured");
+        }
+
+        lock (_endpointLock)
+        {
+            var endpoint = _config.Nmt.ServiceEndpoints[_currentEndpointIndex];
+            _currentEndpointIndex = (_currentEndpointIndex + 1) % _config.Nmt.ServiceEndpoints.Count;
+            return endpoint;
+        }
+    }
+
+    private class NmtResponse
+    {
+        public string? TranslatedText { get; set; }
+    }
+}

--- a/mostlylucid.llmslidetranslator/Services/OllamaClient.cs
+++ b/mostlylucid.llmslidetranslator/Services/OllamaClient.cs
@@ -1,0 +1,198 @@
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using mostlylucid.llmslidetranslator.Models;
+
+namespace mostlylucid.llmslidetranslator.Services;
+
+/// <summary>
+/// Client for Ollama LLM API
+/// </summary>
+public class OllamaClient : IOllamaClient
+{
+    private readonly ILogger<OllamaClient> _logger;
+    private readonly HttpClient _httpClient;
+    private readonly LlmSlideTranslatorConfig _config;
+
+    public OllamaClient(
+        ILogger<OllamaClient> logger,
+        HttpClient httpClient,
+        IOptions<LlmSlideTranslatorConfig> config)
+    {
+        _logger = logger;
+        _httpClient = httpClient;
+        _config = config.Value;
+
+        _httpClient.BaseAddress = new Uri(_config.Ollama.Endpoint);
+        _httpClient.Timeout = TimeSpan.FromSeconds(_config.Ollama.TimeoutSeconds);
+    }
+
+    public async Task<string> TranslateWithContextAsync(
+        TranslationContext context,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("Translating block {BlockId} with Ollama",
+            context.CurrentBlock.BlockId);
+
+        var prompt = BuildPrompt(context);
+
+        var requestBody = new
+        {
+            model = _config.Ollama.Model,
+            prompt,
+            stream = false,
+            options = new
+            {
+                temperature = _config.Ollama.Temperature,
+                num_predict = _config.Ollama.MaxTokens
+            }
+        };
+
+        try
+        {
+            var response = await _httpClient.PostAsJsonAsync(
+                "/api/generate",
+                requestBody,
+                cancellationToken);
+
+            response.EnsureSuccessStatusCode();
+
+            var result = await response.Content.ReadFromJsonAsync<OllamaResponse>(
+                cancellationToken: cancellationToken);
+
+            if (result?.Response == null)
+            {
+                throw new InvalidOperationException("Ollama returned null response");
+            }
+
+            _logger.LogDebug("Ollama translation completed for block {BlockId}",
+                context.CurrentBlock.BlockId);
+
+            return result.Response.Trim();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error translating with Ollama for block {BlockId}",
+                context.CurrentBlock.BlockId);
+            throw;
+        }
+    }
+
+    public async Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var response = await _httpClient.GetAsync("/api/tags", cancellationToken);
+            return response.IsSuccessStatusCode;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Ollama service not available at {Endpoint}",
+                _config.Ollama.Endpoint);
+            return false;
+        }
+    }
+
+    public async Task<List<string>> GetModelsAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var response = await _httpClient.GetAsync("/api/tags", cancellationToken);
+            response.EnsureSuccessStatusCode();
+
+            var result = await response.Content.ReadFromJsonAsync<OllamaModelsResponse>(
+                cancellationToken: cancellationToken);
+
+            return result?.Models?.Select(m => m.Name).ToList() ?? new List<string>();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error getting models from Ollama");
+            return new List<string>();
+        }
+    }
+
+    private string BuildPrompt(TranslationContext context)
+    {
+        var sb = new StringBuilder();
+
+        // System prompt
+        var systemPrompt = context.SystemPrompt ?? GetDefaultSystemPrompt(context.CurrentBlock);
+        sb.AppendLine(systemPrompt);
+        sb.AppendLine();
+
+        // Add context from previous block (sliding window)
+        if (context.PreviousBlock != null && !string.IsNullOrEmpty(context.PreviousBlock.TranslatedText))
+        {
+            sb.AppendLine("Previous block from the same document:");
+            sb.AppendLine("[CTX-PREV]");
+            sb.AppendLine($"EN: {context.PreviousBlock.Text}");
+            sb.AppendLine($"{context.PreviousBlock.TargetLanguage.ToUpper()}: {context.PreviousBlock.TranslatedText}");
+            sb.AppendLine();
+        }
+
+        // Add RAG-retrieved similar blocks
+        if (context.SimilarBlocks.Count > 0)
+        {
+            sb.AppendLine("Context from earlier in the same document (use the same terminology):");
+            for (int i = 0; i < context.SimilarBlocks.Count; i++)
+            {
+                var similarBlock = context.SimilarBlocks[i];
+                if (!string.IsNullOrEmpty(similarBlock.TranslatedText))
+                {
+                    sb.AppendLine($"[CTX-{i + 1}]");
+                    sb.AppendLine($"EN: {similarBlock.Text}");
+                    sb.AppendLine($"{similarBlock.TargetLanguage.ToUpper()}: {similarBlock.TranslatedText}");
+                    sb.AppendLine();
+                }
+            }
+        }
+
+        // Additional context if provided
+        if (!string.IsNullOrEmpty(context.AdditionalContext))
+        {
+            sb.AppendLine(context.AdditionalContext);
+            sb.AppendLine();
+        }
+
+        // The actual text to translate
+        sb.AppendLine("Translate the following text:");
+        sb.AppendLine("<<<SOURCE");
+        sb.AppendLine(context.CurrentBlock.Text);
+        sb.AppendLine("SOURCE>>>");
+        sb.AppendLine();
+        sb.AppendLine($"Return only the {context.CurrentBlock.TargetLanguage.ToUpper()} translation:");
+
+        return sb.ToString();
+    }
+
+    private string GetDefaultSystemPrompt(TranslationBlock block)
+    {
+        return $@"You are a professional translator for technical documentation.
+Translate *only* the [SOURCE] text from {block.SourceLanguage.ToUpper()} to {block.TargetLanguage.ToUpper()}.
+
+Rules:
+- Do NOT translate code, URLs, or technical identifiers
+- Preserve markdown formatting
+- Use the same terminology as shown in the context blocks
+- Maintain the same tone and style
+- Return ONLY the translation, no explanations";
+    }
+
+    private class OllamaResponse
+    {
+        public string? Response { get; set; }
+    }
+
+    private class OllamaModelsResponse
+    {
+        public List<OllamaModel>? Models { get; set; }
+    }
+
+    private class OllamaModel
+    {
+        public required string Name { get; set; }
+    }
+}

--- a/mostlylucid.llmslidetranslator/Services/QdrantVectorStore.cs
+++ b/mostlylucid.llmslidetranslator/Services/QdrantVectorStore.cs
@@ -1,0 +1,254 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using mostlylucid.llmslidetranslator.Models;
+using Qdrant.Client;
+using Qdrant.Client.Grpc;
+
+namespace mostlylucid.llmslidetranslator.Services;
+
+/// <summary>
+/// Qdrant-based vector store for embeddings
+/// </summary>
+public class QdrantVectorStore : IVectorStore
+{
+    private readonly ILogger<QdrantVectorStore> _logger;
+    private readonly IEmbeddingGenerator _embeddingGenerator;
+    private readonly QdrantClient _client;
+    private readonly LlmSlideTranslatorConfig _config;
+    private readonly SemaphoreSlim _initLock = new(1, 1);
+    private bool _collectionInitialized = false;
+
+    public QdrantVectorStore(
+        ILogger<QdrantVectorStore> logger,
+        IEmbeddingGenerator embeddingGenerator,
+        IOptions<LlmSlideTranslatorConfig> config)
+    {
+        _logger = logger;
+        _embeddingGenerator = embeddingGenerator;
+        _config = config.Value;
+
+        var endpoint = _config.Qdrant.Endpoint;
+        _client = new QdrantClient(endpoint, apiKey: _config.Qdrant.ApiKey);
+    }
+
+    private async Task EnsureCollectionExistsAsync(CancellationToken cancellationToken = default)
+    {
+        if (_collectionInitialized)
+            return;
+
+        await _initLock.WaitAsync(cancellationToken);
+        try
+        {
+            if (_collectionInitialized)
+                return;
+
+            var collectionName = _config.Qdrant.CollectionName;
+
+            _logger.LogInformation("Checking if Qdrant collection {CollectionName} exists", collectionName);
+
+            var collections = await _client.ListCollectionsAsync(cancellationToken);
+            var exists = collections.Any(c => c.Name == collectionName);
+
+            if (!exists)
+            {
+                _logger.LogInformation("Creating Qdrant collection {CollectionName}", collectionName);
+
+                await _client.CreateCollectionAsync(
+                    collectionName,
+                    new VectorParams
+                    {
+                        Size = (ulong)_config.Embedding.Dimension,
+                        Distance = Distance.Cosine
+                    },
+                    cancellationToken: cancellationToken);
+
+                _logger.LogInformation("Collection {CollectionName} created successfully", collectionName);
+            }
+
+            _collectionInitialized = true;
+        }
+        finally
+        {
+            _initLock.Release();
+        }
+    }
+
+    public async Task StoreAsync(
+        List<TranslationBlock> blocks,
+        string documentId,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureCollectionExistsAsync(cancellationToken);
+
+        _logger.LogInformation("Storing {Count} blocks for document {DocumentId} in Qdrant",
+            blocks.Count, documentId);
+
+        var collectionName = _config.Qdrant.CollectionName;
+        var points = new List<PointStruct>();
+
+        foreach (var block in blocks)
+        {
+            if (block.Embedding == null)
+            {
+                _logger.LogWarning("Block {BlockId} has no embedding, skipping", block.BlockId);
+                continue;
+            }
+
+            var point = new PointStruct
+            {
+                Id = new PointId { Uuid = block.BlockId },
+                Vectors = block.Embedding,
+                Payload =
+                {
+                    ["documentId"] = documentId,
+                    ["blockId"] = block.BlockId,
+                    ["index"] = block.Index,
+                    ["text"] = block.Text,
+                    ["translatedText"] = block.TranslatedText ?? "",
+                    ["sourceLanguage"] = block.SourceLanguage,
+                    ["targetLanguage"] = block.TargetLanguage,
+                    ["blockType"] = block.BlockType,
+                    ["shouldTranslate"] = block.ShouldTranslate
+                }
+            };
+
+            points.Add(point);
+        }
+
+        if (points.Count > 0)
+        {
+            await _client.UpsertAsync(collectionName, points, cancellationToken: cancellationToken);
+            _logger.LogInformation("Stored {Count} points in Qdrant", points.Count);
+        }
+    }
+
+    public async Task<List<(TranslationBlock Block, float Similarity)>> SearchAsync(
+        float[] queryEmbedding,
+        string documentId,
+        int topK,
+        float minSimilarity = 0.0f,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureCollectionExistsAsync(cancellationToken);
+
+        _logger.LogDebug("Searching for top {TopK} similar blocks in document {DocumentId}",
+            topK, documentId);
+
+        var collectionName = _config.Qdrant.CollectionName;
+
+        var searchResult = await _client.SearchAsync(
+            collectionName,
+            queryEmbedding,
+            limit: (ulong)topK,
+            filter: new Filter
+            {
+                Must =
+                {
+                    new Condition
+                    {
+                        Field = new FieldCondition
+                        {
+                            Key = "documentId",
+                            Match = new Match { Keyword = documentId }
+                        }
+                    }
+                }
+            },
+            scoreThreshold: minSimilarity,
+            cancellationToken: cancellationToken);
+
+        var results = searchResult.Select(r =>
+        {
+            var block = new TranslationBlock
+            {
+                BlockId = r.Payload["blockId"].StringValue,
+                Index = (int)r.Payload["index"].IntegerValue,
+                DocumentId = r.Payload["documentId"].StringValue,
+                Text = r.Payload["text"].StringValue,
+                TranslatedText = r.Payload["translatedText"].StringValue,
+                SourceLanguage = r.Payload["sourceLanguage"].StringValue,
+                TargetLanguage = r.Payload["targetLanguage"].StringValue,
+                BlockType = r.Payload["blockType"].StringValue,
+                ShouldTranslate = r.Payload["shouldTranslate"].BoolValue,
+                Embedding = r.Vectors.Vector.Data.ToArray()
+            };
+
+            return (block, (float)r.Score);
+        }).ToList();
+
+        _logger.LogDebug("Found {Count} similar blocks above threshold {MinSimilarity}",
+            results.Count, minSimilarity);
+
+        return results;
+    }
+
+    public async Task<List<TranslationBlock>> GetDocumentBlocksAsync(
+        string documentId,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureCollectionExistsAsync(cancellationToken);
+
+        var collectionName = _config.Qdrant.CollectionName;
+
+        var scrollResult = await _client.ScrollAsync(
+            collectionName,
+            filter: new Filter
+            {
+                Must =
+                {
+                    new Condition
+                    {
+                        Field = new FieldCondition
+                        {
+                            Key = "documentId",
+                            Match = new Match { Keyword = documentId }
+                        }
+                    }
+                }
+            },
+            cancellationToken: cancellationToken);
+
+        var blocks = scrollResult.Select(r => new TranslationBlock
+        {
+            BlockId = r.Payload["blockId"].StringValue,
+            Index = (int)r.Payload["index"].IntegerValue,
+            DocumentId = r.Payload["documentId"].StringValue,
+            Text = r.Payload["text"].StringValue,
+            TranslatedText = r.Payload["translatedText"].StringValue,
+            SourceLanguage = r.Payload["sourceLanguage"].StringValue,
+            TargetLanguage = r.Payload["targetLanguage"].StringValue,
+            BlockType = r.Payload["blockType"].StringValue,
+            ShouldTranslate = r.Payload["shouldTranslate"].BoolValue,
+            Embedding = r.Vectors.Vector.Data.ToArray()
+        }).ToList();
+
+        return blocks;
+    }
+
+    public async Task ClearDocumentAsync(string documentId, CancellationToken cancellationToken = default)
+    {
+        await EnsureCollectionExistsAsync(cancellationToken);
+
+        var collectionName = _config.Qdrant.CollectionName;
+
+        await _client.DeleteAsync(
+            collectionName,
+            filter: new Filter
+            {
+                Must =
+                {
+                    new Condition
+                    {
+                        Field = new FieldCondition
+                        {
+                            Key = "documentId",
+                            Match = new Match { Keyword = documentId }
+                        }
+                    }
+                }
+            },
+            cancellationToken: cancellationToken);
+
+        _logger.LogInformation("Cleared document {DocumentId} from Qdrant", documentId);
+    }
+}

--- a/mostlylucid.llmslidetranslator/Services/TranslationComparer.cs
+++ b/mostlylucid.llmslidetranslator/Services/TranslationComparer.cs
@@ -1,0 +1,153 @@
+using Microsoft.Extensions.Logging;
+using mostlylucid.llmslidetranslator.Models;
+
+namespace mostlylucid.llmslidetranslator.Services;
+
+/// <summary>
+/// Service for comparing translations
+/// </summary>
+public class TranslationComparer : ITranslationComparer
+{
+    private readonly ILogger<TranslationComparer> _logger;
+    private readonly IEmbeddingGenerator _embeddingGenerator;
+
+    public TranslationComparer(
+        ILogger<TranslationComparer> logger,
+        IEmbeddingGenerator embeddingGenerator)
+    {
+        _logger = logger;
+        _embeddingGenerator = embeddingGenerator;
+    }
+
+    public async Task<TranslationComparison> CompareAsync(
+        TranslationResult result1,
+        TranslationResult result2,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation(
+            "Comparing translations for document {DocumentId} using methods {Method1} vs {Method2}",
+            result1.DocumentId, result1.Method, result2.Method);
+
+        var comparison = new TranslationComparison
+        {
+            DocumentId = result1.DocumentId,
+            Translation1 = result1,
+            Translation2 = result2
+        };
+
+        // Ensure both have the same number of blocks
+        var maxBlocks = Math.Max(result1.Blocks.Count, result2.Blocks.Count);
+
+        for (int i = 0; i < maxBlocks; i++)
+        {
+            var block1 = i < result1.Blocks.Count ? result1.Blocks[i] : null;
+            var block2 = i < result2.Blocks.Count ? result2.Blocks[i] : null;
+
+            if (block1 == null || block2 == null)
+            {
+                continue;
+            }
+
+            var text1 = block1.TranslatedText ?? block1.Text;
+            var text2 = block2.TranslatedText ?? block2.Text;
+
+            var editDistance = CalculateEditDistance(text1, text2);
+            var maxLength = Math.Max(text1.Length, text2.Length);
+            var similarity = maxLength > 0 ? 1.0f - (float)editDistance / maxLength : 1.0f;
+
+            var difference = new BlockDifference
+            {
+                BlockIndex = i,
+                Text1 = text1,
+                Text2 = text2,
+                Similarity = similarity,
+                EditDistance = editDistance
+            };
+
+            comparison.Differences.Add(difference);
+        }
+
+        // Calculate overall similarity
+        if (comparison.Differences.Count > 0)
+        {
+            comparison.SimilarityScore = comparison.Differences.Average(d => d.Similarity);
+        }
+
+        _logger.LogInformation(
+            "Comparison completed. Overall similarity: {Similarity:F2}",
+            comparison.SimilarityScore);
+
+        return comparison;
+    }
+
+    public int CalculateEditDistance(string text1, string text2)
+    {
+        if (string.IsNullOrEmpty(text1))
+            return text2?.Length ?? 0;
+
+        if (string.IsNullOrEmpty(text2))
+            return text1.Length;
+
+        var len1 = text1.Length;
+        var len2 = text2.Length;
+
+        var matrix = new int[len1 + 1, len2 + 1];
+
+        // Initialize first column and row
+        for (int i = 0; i <= len1; i++)
+            matrix[i, 0] = i;
+
+        for (int j = 0; j <= len2; j++)
+            matrix[0, j] = j;
+
+        // Calculate distances
+        for (int i = 1; i <= len1; i++)
+        {
+            for (int j = 1; j <= len2; j++)
+            {
+                var cost = text1[i - 1] == text2[j - 1] ? 0 : 1;
+
+                matrix[i, j] = Math.Min(
+                    Math.Min(
+                        matrix[i - 1, j] + 1,      // Deletion
+                        matrix[i, j - 1] + 1),     // Insertion
+                    matrix[i - 1, j - 1] + cost);  // Substitution
+            }
+        }
+
+        return matrix[len1, len2];
+    }
+
+    public float CalculateBleuScore(string reference, string candidate)
+    {
+        // Simplified BLEU-1 score (unigram precision)
+        // For a full BLEU implementation, consider using a library
+
+        if (string.IsNullOrWhiteSpace(reference) || string.IsNullOrWhiteSpace(candidate))
+        {
+            return 0;
+        }
+
+        var refTokens = reference.ToLower().Split(new[] { ' ', '\t', '\n', '\r' },
+            StringSplitOptions.RemoveEmptyEntries);
+        var candTokens = candidate.ToLower().Split(new[] { ' ', '\t', '\n', '\r' },
+            StringSplitOptions.RemoveEmptyEntries);
+
+        if (candTokens.Length == 0)
+        {
+            return 0;
+        }
+
+        var refSet = new HashSet<string>(refTokens);
+        var matchCount = candTokens.Count(token => refSet.Contains(token));
+
+        var precision = (float)matchCount / candTokens.Length;
+
+        // Brevity penalty
+        var brevityPenalty = candTokens.Length < refTokens.Length
+            ? MathF.Exp(1 - (float)refTokens.Length / candTokens.Length)
+            : 1.0f;
+
+        return precision * brevityPenalty;
+    }
+}

--- a/mostlylucid.llmslidetranslator/mostlylucid.llmslidetranslator.csproj
+++ b/mostlylucid.llmslidetranslator/mostlylucid.llmslidetranslator.csproj
@@ -1,0 +1,61 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <PackageId>mostlylucid.llmslidetranslator</PackageId>
+        <Version>1.0.0</Version>
+        <Authors>mostlylucid</Authors>
+        <Company>mostlylucid</Company>
+        <Product>mostlylucid.llmslidetranslator</Product>
+        <Description>RAG-assisted translation for long documents using small local LLMs with sliding-window chunking and vector similarity search. Preserves translation consistency across paragraphs.</Description>
+        <PackageTags>llm;translation;rag;ollama;nmt;embeddings;mostlylucid</PackageTags>
+        <RepositoryUrl>https://github.com/scottgal/mostlylucidweb/tree/main/mostlylucid.llmslidetranslator</RepositoryUrl>
+        <PackageLicenseExpression>Unlicense</PackageLicenseExpression>
+        <PackageIcon>icon.png</PackageIcon>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <PackageReleaseNotes>$([System.IO.File]::ReadAllText("$(MSBuildProjectDirectory)/release-notes.txt"))</PackageReleaseNotes>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+        <AssemblyName>mostlylucid.llmslidetranslator</AssemblyName>
+        <RootNamespace>mostlylucid.llmslidetranslator</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <!-- Core dependencies -->
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.10" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.10" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.10" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.10" />
+        <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.10" />
+
+        <!-- LLM and embeddings -->
+        <PackageReference Include="LLamaSharp" Version="0.22.0" />
+        <PackageReference Include="LLamaSharp.Backend.Cpu" Version="0.22.0" />
+
+        <!-- Markdown processing -->
+        <PackageReference Include="Markdig" Version="0.43.0" />
+
+        <!-- JSON -->
+        <PackageReference Include="System.Text.Json" Version="9.0.10" />
+
+        <!-- Hashing -->
+        <PackageReference Include="System.IO.Hashing" Version="9.0.10" />
+
+        <!-- Qdrant (optional vector store) -->
+        <PackageReference Include="Qdrant.Client" Version="1.12.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <None Include=".\icon.png" Pack="true" PackagePath="" Condition="Exists('.\icon.png')">
+            <Link>Properties\icon.png</Link>
+        </None>
+        <None Include=".\README.md" Pack="true" PackagePath="" Condition="Exists('.\README.md')">
+            <Link>Properties\README.md</Link>
+        </None>
+        <None Include=".\release-notes.txt" Pack="true" PackagePath="" Condition="Exists('.\release-notes.txt')">
+            <Link>Properties\release-notes.txt</Link>
+        </None>
+    </ItemGroup>
+</Project>

--- a/mostlylucid.llmslidetranslator/release-notes.txt
+++ b/mostlylucid.llmslidetranslator/release-notes.txt
@@ -1,0 +1,23 @@
+Version 1.0.0 - Initial Release
+
+Features:
+- RAG-assisted translation using small local LLMs
+- Multiple translation methods (RAG+LLM, LLM-only, NMT+LLM, NMT-only)
+- Sliding-window context for translation continuity
+- Vector similarity search for terminology consistency
+- File-based and Qdrant vector store providers
+- Markdown-aware chunking that preserves document structure
+- Translation comparison functionality
+- Integration with Ollama for local LLM inference
+- Integration with Opus-MT NMT service (mostlyucid-nmt)
+- LlamaSharp-based embedding generation
+- ASP.NET Minimal API demo with SignalR streaming
+- Real-time translation progress tracking
+- Server-sent events (SSE) streaming endpoint
+
+Requirements:
+- .NET 9.0 or later
+- Ollama with a local model (e.g., llama3.2:3b)
+- Embedding model in GGUF format (e.g., nomic-embed-text-v1.5)
+- Optional: Qdrant vector database
+- Optional: NMT service from mostlyucid-nmt


### PR DESCRIPTION
- Create mostlylucid.llmslidetranslator NuGet package
- RAG-enhanced translation for long documents using small local LLMs
- Sliding-window chunking with vector similarity search
- Multiple translation methods (RAG+LLM, LLM-only, NMT+LLM, NMT-only)
- File-based and Qdrant vector store providers
- Markdown-aware chunking preserving document structure
- LlamaSharp-based embedding generation
- Ollama LLM integration for local inference
- NMT service integration (mostlyucid-nmt/Opus-MT)
- Translation comparison functionality

Demo API Features:
- ASP.NET Minimal API with Swagger documentation
- SignalR hub for real-time translation updates
- Server-sent events (SSE) streaming endpoint
- Interactive HTML client with live progress tracking
- Multiple simultaneous document translations
- Service status checking

Package includes:
- Complete service implementations
- DI extension methods
- Comprehensive configuration options
- README and release notes
- Demo API with web UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)