### PR TITLE
Build multi-format document conversion service

### DIFF
--- a/Mostlylucid.DocumentConversion.Demo/Controllers/ConversionController.cs
+++ b/Mostlylucid.DocumentConversion.Demo/Controllers/ConversionController.cs
@@ -1,0 +1,269 @@
+using Microsoft.AspNetCore.Mvc;
+using Mostlylucid.DocumentConversion.Interfaces;
+using Mostlylucid.DocumentConversion.Models;
+
+namespace Mostlylucid.DocumentConversion.Demo.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class ConversionController : ControllerBase
+{
+    private readonly IDocumentConversionService _conversionService;
+    private readonly ILogger<ConversionController> _logger;
+
+    public ConversionController(
+        IDocumentConversionService conversionService,
+        ILogger<ConversionController> logger)
+    {
+        _conversionService = conversionService;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Convert a Word document to Markdown
+    /// </summary>
+    [HttpPost("word-to-markdown")]
+    public async Task<IActionResult> WordToMarkdown(IFormFile file)
+    {
+        if (file == null || file.Length == 0)
+            return BadRequest("No file uploaded");
+
+        if (!file.FileName.EndsWith(".docx", StringComparison.OrdinalIgnoreCase))
+            return BadRequest("Only .docx files are supported");
+
+        try
+        {
+            await using var stream = file.OpenReadStream();
+            var markdown = await _conversionService.WordToMarkdownAsync(stream);
+
+            return Ok(new { markdown, fileName = Path.ChangeExtension(file.FileName, ".md") });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to convert Word to Markdown");
+            return StatusCode(500, new { error = ex.Message });
+        }
+    }
+
+    /// <summary>
+    /// Convert a Word document to PDF
+    /// </summary>
+    [HttpPost("word-to-pdf")]
+    public async Task<IActionResult> WordToPdf(IFormFile file)
+    {
+        if (file == null || file.Length == 0)
+            return BadRequest("No file uploaded");
+
+        if (!file.FileName.EndsWith(".docx", StringComparison.OrdinalIgnoreCase))
+            return BadRequest("Only .docx files are supported");
+
+        try
+        {
+            await using var stream = file.OpenReadStream();
+            var pdfBytes = await _conversionService.WordToPdfAsync(stream);
+
+            return File(pdfBytes, "application/pdf", Path.ChangeExtension(file.FileName, ".pdf"));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to convert Word to PDF");
+            return StatusCode(500, new { error = ex.Message });
+        }
+    }
+
+    /// <summary>
+    /// Convert Markdown to Word document
+    /// </summary>
+    [HttpPost("markdown-to-word")]
+    public async Task<IActionResult> MarkdownToWord([FromBody] MarkdownInput input)
+    {
+        if (string.IsNullOrWhiteSpace(input.Markdown))
+            return BadRequest("Markdown content is required");
+
+        try
+        {
+            var wordBytes = await _conversionService.MarkdownToWordAsync(input.Markdown);
+            var fileName = string.IsNullOrEmpty(input.FileName)
+                ? "document.docx"
+                : Path.ChangeExtension(input.FileName, ".docx");
+
+            return File(wordBytes,
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                fileName);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to convert Markdown to Word");
+            return StatusCode(500, new { error = ex.Message });
+        }
+    }
+
+    /// <summary>
+    /// Convert Markdown to PDF
+    /// </summary>
+    [HttpPost("markdown-to-pdf")]
+    public async Task<IActionResult> MarkdownToPdf([FromBody] MarkdownInput input)
+    {
+        if (string.IsNullOrWhiteSpace(input.Markdown))
+            return BadRequest("Markdown content is required");
+
+        try
+        {
+            var options = new ConversionOptions
+            {
+                PageSize = input.PageSize ?? PdfPageSize.A4,
+                Orientation = input.Orientation ?? PdfOrientation.Portrait
+            };
+
+            var pdfBytes = await _conversionService.MarkdownToPdfAsync(input.Markdown, options);
+            var fileName = string.IsNullOrEmpty(input.FileName)
+                ? "document.pdf"
+                : Path.ChangeExtension(input.FileName, ".pdf");
+
+            return File(pdfBytes, "application/pdf", fileName);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to convert Markdown to PDF");
+            return StatusCode(500, new { error = ex.Message });
+        }
+    }
+
+    /// <summary>
+    /// Extract elements from a document
+    /// </summary>
+    [HttpPost("extract-elements")]
+    public async Task<IActionResult> ExtractElements(IFormFile file)
+    {
+        if (file == null || file.Length == 0)
+            return BadRequest("No file uploaded");
+
+        try
+        {
+            await using var stream = file.OpenReadStream();
+            var elements = await _conversionService.ExtractElementsAsync(stream, file.FileName);
+
+            return Ok(new
+            {
+                fileName = file.FileName,
+                elementCount = elements.Count,
+                elements = elements.Select(e => new
+                {
+                    type = e.ElementType.ToString(),
+                    order = e.Order,
+                    content = GetElementContent(e)
+                })
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to extract elements");
+            return StatusCode(500, new { error = ex.Message });
+        }
+    }
+
+    /// <summary>
+    /// Extract text from a document
+    /// </summary>
+    [HttpPost("extract-text")]
+    public async Task<IActionResult> ExtractText(IFormFile file)
+    {
+        if (file == null || file.Length == 0)
+            return BadRequest("No file uploaded");
+
+        try
+        {
+            await using var stream = file.OpenReadStream();
+            var text = await _conversionService.ExtractTextAsync(stream, file.FileName);
+
+            return Ok(new { text, wordCount = CountWords(text) });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to extract text");
+            return StatusCode(500, new { error = ex.Message });
+        }
+    }
+
+    /// <summary>
+    /// Extract images from a Word document
+    /// </summary>
+    [HttpPost("extract-images")]
+    public async Task<IActionResult> ExtractImages(IFormFile file)
+    {
+        if (file == null || file.Length == 0)
+            return BadRequest("No file uploaded");
+
+        try
+        {
+            await using var stream = file.OpenReadStream();
+            var images = await _conversionService.ExtractImagesAsync(stream, file.FileName);
+
+            return Ok(new
+            {
+                imageCount = images.Count,
+                images = images.Select((img, i) => new
+                {
+                    index = i,
+                    fileName = img.FileName ?? $"image{i + 1}",
+                    contentType = img.ContentType,
+                    width = img.Width,
+                    height = img.Height,
+                    dataUri = img.DataUri
+                })
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to extract images");
+            return StatusCode(500, new { error = ex.Message });
+        }
+    }
+
+    /// <summary>
+    /// Get supported formats
+    /// </summary>
+    [HttpGet("formats")]
+    public IActionResult GetFormats()
+    {
+        return Ok(new
+        {
+            readable = new[] { "docx", "md", "txt" },
+            writable = new[] { "docx", "md", "pdf", "html", "txt" },
+            conversions = new[]
+            {
+                new { from = "docx", to = new[] { "md", "pdf", "html", "txt" } },
+                new { from = "md", to = new[] { "docx", "pdf", "html", "txt" } },
+                new { from = "txt", to = new[] { "docx", "md", "pdf", "html" } }
+            }
+        });
+    }
+
+    private static string GetElementContent(DocumentElement element)
+    {
+        return element switch
+        {
+            HeadingElement h => $"[H{h.Level}] {h.Text}",
+            ParagraphElement p => p.Text.Length > 100 ? p.Text[..100] + "..." : p.Text,
+            TableElement t => $"[Table: {t.Rows.Count} rows]",
+            ListElement l => $"[List: {l.Items.Count} items]",
+            CodeBlockElement c => $"[Code: {c.Language ?? "unknown"}] {c.Code.Length} chars",
+            ImageElement i => $"[Image: {i.Width}x{i.Height}]",
+            _ => element.ElementType.ToString()
+        };
+    }
+
+    private static int CountWords(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text)) return 0;
+        return text.Split([' ', '\n', '\r', '\t'], StringSplitOptions.RemoveEmptyEntries).Length;
+    }
+}
+
+public class MarkdownInput
+{
+    public string Markdown { get; set; } = string.Empty;
+    public string? FileName { get; set; }
+    public PdfPageSize? PageSize { get; set; }
+    public PdfOrientation? Orientation { get; set; }
+}

--- a/Mostlylucid.DocumentConversion.Demo/Mostlylucid.DocumentConversion.Demo.csproj
+++ b/Mostlylucid.DocumentConversion.Demo/Mostlylucid.DocumentConversion.Demo.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AssemblyName>Mostlylucid.DocumentConversion.Demo</AssemblyName>
+    <RootNamespace>Mostlylucid.DocumentConversion.Demo</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Mostlylucid.DocumentConversion\Mostlylucid.DocumentConversion.csproj"/>
+  </ItemGroup>
+
+</Project>

--- a/Mostlylucid.DocumentConversion.Demo/Program.cs
+++ b/Mostlylucid.DocumentConversion.Demo/Program.cs
@@ -1,0 +1,42 @@
+using Mostlylucid.DocumentConversion.Extensions;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+
+// Register document conversion services
+builder.Services.AddDocumentConversion();
+
+// Add CORS for development
+builder.Services.AddCors(options =>
+{
+    options.AddDefaultPolicy(policy =>
+    {
+        policy.AllowAnyOrigin()
+            .AllowAnyMethod()
+            .AllowAnyHeader();
+    });
+});
+
+// Configure logging
+builder.Logging.ClearProviders();
+builder.Logging.AddConsole();
+builder.Logging.AddDebug();
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline
+if (app.Environment.IsDevelopment()) app.UseDeveloperExceptionPage();
+
+app.UseStaticFiles();
+app.UseCors();
+
+app.UseRouting();
+app.MapControllers();
+
+// Default route to serve the HTML page
+app.MapGet("/", () => Results.Redirect("/index.html"));
+
+app.Run();

--- a/Mostlylucid.DocumentConversion.Demo/wwwroot/index.html
+++ b/Mostlylucid.DocumentConversion.Demo/wwwroot/index.html
@@ -1,0 +1,277 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document Conversion Demo</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 min-h-screen">
+    <div class="container mx-auto px-4 py-8">
+        <h1 class="text-3xl font-bold text-center mb-8">Document Conversion Service Demo</h1>
+
+        <div class="grid md:grid-cols-2 gap-6">
+            <!-- Word to Markdown -->
+            <div class="bg-white rounded-lg shadow p-6">
+                <h2 class="text-xl font-semibold mb-4">Word to Markdown</h2>
+                <form id="wordToMdForm" class="space-y-4">
+                    <input type="file" accept=".docx" id="wordToMdFile" class="block w-full text-sm border rounded p-2">
+                    <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600">Convert</button>
+                </form>
+                <div id="wordToMdResult" class="mt-4 hidden">
+                    <h3 class="font-medium mb-2">Result:</h3>
+                    <pre class="bg-gray-100 p-3 rounded text-sm overflow-auto max-h-64"></pre>
+                    <button class="mt-2 bg-green-500 text-white px-3 py-1 rounded text-sm download-btn">Download .md</button>
+                </div>
+            </div>
+
+            <!-- Word to PDF -->
+            <div class="bg-white rounded-lg shadow p-6">
+                <h2 class="text-xl font-semibold mb-4">Word to PDF</h2>
+                <form id="wordToPdfForm" class="space-y-4">
+                    <input type="file" accept=".docx" id="wordToPdfFile" class="block w-full text-sm border rounded p-2">
+                    <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600">Convert</button>
+                </form>
+                <div id="wordToPdfResult" class="mt-4 hidden">
+                    <p class="text-green-600">PDF generated successfully!</p>
+                </div>
+            </div>
+
+            <!-- Markdown to Word -->
+            <div class="bg-white rounded-lg shadow p-6">
+                <h2 class="text-xl font-semibold mb-4">Markdown to Word</h2>
+                <form id="mdToWordForm" class="space-y-4">
+                    <textarea id="mdToWordInput" rows="6" placeholder="Enter Markdown content..."
+                        class="w-full border rounded p-2 text-sm font-mono"># Sample Document
+
+This is a **bold** and *italic* text.
+
+## Features
+
+- Item 1
+- Item 2
+- Item 3
+
+```csharp
+Console.WriteLine("Hello World!");
+```</textarea>
+                    <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600">Convert</button>
+                </form>
+            </div>
+
+            <!-- Markdown to PDF -->
+            <div class="bg-white rounded-lg shadow p-6">
+                <h2 class="text-xl font-semibold mb-4">Markdown to PDF</h2>
+                <form id="mdToPdfForm" class="space-y-4">
+                    <textarea id="mdToPdfInput" rows="6" placeholder="Enter Markdown content..."
+                        class="w-full border rounded p-2 text-sm font-mono"># Report Title
+
+## Introduction
+
+This document demonstrates Markdown to PDF conversion.
+
+| Column 1 | Column 2 |
+|----------|----------|
+| Data A   | Data B   |
+| Data C   | Data D   |
+
+## Conclusion
+
+PDF generation using QuestPDF.</textarea>
+                    <div class="flex gap-4">
+                        <select id="pageSize" class="border rounded p-2">
+                            <option value="A4">A4</option>
+                            <option value="Letter">Letter</option>
+                            <option value="A3">A3</option>
+                            <option value="A5">A5</option>
+                        </select>
+                        <select id="orientation" class="border rounded p-2">
+                            <option value="Portrait">Portrait</option>
+                            <option value="Landscape">Landscape</option>
+                        </select>
+                    </div>
+                    <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600">Convert</button>
+                </form>
+            </div>
+
+            <!-- Extract Elements -->
+            <div class="bg-white rounded-lg shadow p-6">
+                <h2 class="text-xl font-semibold mb-4">Extract Elements</h2>
+                <form id="extractElementsForm" class="space-y-4">
+                    <input type="file" accept=".docx,.md,.txt" id="extractElementsFile" class="block w-full text-sm border rounded p-2">
+                    <button type="submit" class="bg-purple-500 text-white px-4 py-2 rounded hover:bg-purple-600">Extract</button>
+                </form>
+                <div id="extractElementsResult" class="mt-4 hidden">
+                    <h3 class="font-medium mb-2">Elements (<span class="count"></span>):</h3>
+                    <div class="bg-gray-100 p-3 rounded text-sm overflow-auto max-h-64 elements-list"></div>
+                </div>
+            </div>
+
+            <!-- Extract Images -->
+            <div class="bg-white rounded-lg shadow p-6">
+                <h2 class="text-xl font-semibold mb-4">Extract Images</h2>
+                <form id="extractImagesForm" class="space-y-4">
+                    <input type="file" accept=".docx" id="extractImagesFile" class="block w-full text-sm border rounded p-2">
+                    <button type="submit" class="bg-purple-500 text-white px-4 py-2 rounded hover:bg-purple-600">Extract</button>
+                </form>
+                <div id="extractImagesResult" class="mt-4 hidden">
+                    <h3 class="font-medium mb-2">Images (<span class="count"></span>):</h3>
+                    <div class="grid grid-cols-3 gap-2 images-grid"></div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Supported Formats -->
+        <div class="mt-8 bg-white rounded-lg shadow p-6">
+            <h2 class="text-xl font-semibold mb-4">Supported Formats</h2>
+            <div id="formats" class="text-sm text-gray-600">Loading...</div>
+        </div>
+    </div>
+
+    <script>
+        // Load supported formats
+        fetch('/api/conversion/formats')
+            .then(r => r.json())
+            .then(data => {
+                document.getElementById('formats').innerHTML = `
+                    <p><strong>Readable:</strong> ${data.readable.join(', ')}</p>
+                    <p><strong>Writable:</strong> ${data.writable.join(', ')}</p>
+                `;
+            });
+
+        // Word to Markdown
+        document.getElementById('wordToMdForm').addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const file = document.getElementById('wordToMdFile').files[0];
+            if (!file) return alert('Please select a file');
+
+            const formData = new FormData();
+            formData.append('file', file);
+
+            const res = await fetch('/api/conversion/word-to-markdown', { method: 'POST', body: formData });
+            const data = await res.json();
+
+            const result = document.getElementById('wordToMdResult');
+            result.classList.remove('hidden');
+            result.querySelector('pre').textContent = data.markdown;
+            result.querySelector('.download-btn').onclick = () => {
+                const blob = new Blob([data.markdown], { type: 'text/markdown' });
+                const url = URL.createObjectURL(blob);
+                const a = document.createElement('a');
+                a.href = url;
+                a.download = data.fileName;
+                a.click();
+            };
+        });
+
+        // Word to PDF
+        document.getElementById('wordToPdfForm').addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const file = document.getElementById('wordToPdfFile').files[0];
+            if (!file) return alert('Please select a file');
+
+            const formData = new FormData();
+            formData.append('file', file);
+
+            const res = await fetch('/api/conversion/word-to-pdf', { method: 'POST', body: formData });
+            const blob = await res.blob();
+
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = file.name.replace('.docx', '.pdf');
+            a.click();
+
+            document.getElementById('wordToPdfResult').classList.remove('hidden');
+        });
+
+        // Markdown to Word
+        document.getElementById('mdToWordForm').addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const markdown = document.getElementById('mdToWordInput').value;
+
+            const res = await fetch('/api/conversion/markdown-to-word', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ markdown, fileName: 'document' })
+            });
+            const blob = await res.blob();
+
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = 'document.docx';
+            a.click();
+        });
+
+        // Markdown to PDF
+        document.getElementById('mdToPdfForm').addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const markdown = document.getElementById('mdToPdfInput').value;
+            const pageSize = document.getElementById('pageSize').value;
+            const orientation = document.getElementById('orientation').value;
+
+            const pageSizeMap = { 'A4': 0, 'A3': 1, 'A5': 2, 'Letter': 3, 'Legal': 4 };
+            const orientationMap = { 'Portrait': 0, 'Landscape': 1 };
+
+            const res = await fetch('/api/conversion/markdown-to-pdf', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    markdown,
+                    fileName: 'document',
+                    pageSize: pageSizeMap[pageSize],
+                    orientation: orientationMap[orientation]
+                })
+            });
+            const blob = await res.blob();
+
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = 'document.pdf';
+            a.click();
+        });
+
+        // Extract Elements
+        document.getElementById('extractElementsForm').addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const file = document.getElementById('extractElementsFile').files[0];
+            if (!file) return alert('Please select a file');
+
+            const formData = new FormData();
+            formData.append('file', file);
+
+            const res = await fetch('/api/conversion/extract-elements', { method: 'POST', body: formData });
+            const data = await res.json();
+
+            const result = document.getElementById('extractElementsResult');
+            result.classList.remove('hidden');
+            result.querySelector('.count').textContent = data.elementCount;
+            result.querySelector('.elements-list').innerHTML = data.elements
+                .map(e => `<div class="mb-1"><span class="text-blue-600">${e.type}</span>: ${e.content}</div>`)
+                .join('');
+        });
+
+        // Extract Images
+        document.getElementById('extractImagesForm').addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const file = document.getElementById('extractImagesFile').files[0];
+            if (!file) return alert('Please select a file');
+
+            const formData = new FormData();
+            formData.append('file', file);
+
+            const res = await fetch('/api/conversion/extract-images', { method: 'POST', body: formData });
+            const data = await res.json();
+
+            const result = document.getElementById('extractImagesResult');
+            result.classList.remove('hidden');
+            result.querySelector('.count').textContent = data.imageCount;
+            result.querySelector('.images-grid').innerHTML = data.images
+                .map(img => `<img src="${img.dataUri}" alt="${img.fileName}" class="w-full rounded border" title="${img.width}x${img.height}">`)
+                .join('');
+        });
+    </script>
+</body>
+</html>

--- a/Mostlylucid.DocumentConversion.Test/DocumentConversionServiceTests.cs
+++ b/Mostlylucid.DocumentConversion.Test/DocumentConversionServiceTests.cs
@@ -1,0 +1,309 @@
+using Microsoft.Extensions.Logging;
+using Mostlylucid.DocumentConversion.Interfaces;
+using Mostlylucid.DocumentConversion.Models;
+using Mostlylucid.DocumentConversion.Services;
+
+namespace Mostlylucid.DocumentConversion.Test;
+
+public class DocumentConversionServiceTests
+{
+    private readonly IDocumentConversionService _service;
+
+    public DocumentConversionServiceTests()
+    {
+        var wordLogger = new Mock<ILogger<WordDocumentService>>();
+        var mdLogger = new Mock<ILogger<MarkdownConversionService>>();
+        var pdfLogger = new Mock<ILogger<PdfConversionService>>();
+        var serviceLogger = new Mock<ILogger<DocumentConversionService>>();
+
+        var wordService = new WordDocumentService(wordLogger.Object);
+        var mdService = new MarkdownConversionService(mdLogger.Object);
+        var pdfService = new PdfConversionService(pdfLogger.Object, mdService);
+
+        _service = new DocumentConversionService(
+            serviceLogger.Object,
+            wordService,
+            mdService,
+            pdfService);
+    }
+
+    [Theory]
+    [InlineData("document.docx", DocumentFormat.Word)]
+    [InlineData("document.DOCX", DocumentFormat.Word)]
+    [InlineData("readme.md", DocumentFormat.Markdown)]
+    [InlineData("README.MD", DocumentFormat.Markdown)]
+    [InlineData("notes.txt", DocumentFormat.PlainText)]
+    [InlineData("report.pdf", DocumentFormat.Pdf)]
+    [InlineData("page.html", DocumentFormat.Html)]
+    [InlineData("page.htm", DocumentFormat.Html)]
+    [InlineData("unknown.xyz", DocumentFormat.Unknown)]
+    public void DetectFormat_VariousExtensions_DetectsCorrectly(string fileName, DocumentFormat expected)
+    {
+        // Act
+        var format = _service.DetectFormat(fileName);
+
+        // Assert
+        Assert.Equal(expected, format);
+    }
+
+    [Theory]
+    [InlineData(DocumentFormat.Word, true)]
+    [InlineData(DocumentFormat.Markdown, true)]
+    [InlineData(DocumentFormat.PlainText, true)]
+    [InlineData(DocumentFormat.Pdf, false)]
+    [InlineData(DocumentFormat.Html, false)]
+    [InlineData(DocumentFormat.Unknown, false)]
+    public void CanRead_VariousFormats_ReturnsCorrectly(DocumentFormat format, bool expected)
+    {
+        // Act
+        var canRead = _service.CanRead(format);
+
+        // Assert
+        Assert.Equal(expected, canRead);
+    }
+
+    [Theory]
+    [InlineData(DocumentFormat.Word, true)]
+    [InlineData(DocumentFormat.Markdown, true)]
+    [InlineData(DocumentFormat.Pdf, true)]
+    [InlineData(DocumentFormat.Html, true)]
+    [InlineData(DocumentFormat.PlainText, true)]
+    [InlineData(DocumentFormat.Unknown, false)]
+    public void CanWrite_VariousFormats_ReturnsCorrectly(DocumentFormat format, bool expected)
+    {
+        // Act
+        var canWrite = _service.CanWrite(format);
+
+        // Assert
+        Assert.Equal(expected, canWrite);
+    }
+
+    [Fact]
+    public async Task MarkdownToWordAsync_ValidMarkdown_ReturnsDocxBytes()
+    {
+        // Arrange
+        var markdown = "# Test Document\n\nThis is a test.";
+
+        // Act
+        var bytes = await _service.MarkdownToWordAsync(markdown);
+
+        // Assert
+        Assert.NotNull(bytes);
+        Assert.True(bytes.Length > 0);
+        // DOCX files start with PK (ZIP signature)
+        Assert.Equal(0x50, bytes[0]); // 'P'
+        Assert.Equal(0x4B, bytes[1]); // 'K'
+    }
+
+    [Fact]
+    public async Task MarkdownToPdfAsync_ValidMarkdown_ReturnsPdfBytes()
+    {
+        // Arrange
+        var markdown = "# Test Document\n\nThis is a test.";
+
+        // Act
+        var bytes = await _service.MarkdownToPdfAsync(markdown);
+
+        // Assert
+        Assert.NotNull(bytes);
+        Assert.True(bytes.Length > 0);
+        // PDF files start with %PDF
+        Assert.Equal(0x25, bytes[0]); // '%'
+        Assert.Equal(0x50, bytes[1]); // 'P'
+        Assert.Equal(0x44, bytes[2]); // 'D'
+        Assert.Equal(0x46, bytes[3]); // 'F'
+    }
+
+    [Fact]
+    public async Task ReadDocumentAsync_MarkdownBytes_ParsesCorrectly()
+    {
+        // Arrange
+        var markdown = "# Hello World\n\nTest content.";
+        var bytes = System.Text.Encoding.UTF8.GetBytes(markdown);
+
+        // Act
+        var document = await _service.ReadDocumentAsync(bytes, "test.md");
+
+        // Assert
+        Assert.NotNull(document);
+        Assert.Equal(DocumentFormat.Markdown, document.SourceFormat);
+        Assert.Equal(2, document.Elements.Count);
+    }
+
+    [Fact]
+    public async Task ConvertAsync_DocumentToMarkdown_ReturnsMarkdownResult()
+    {
+        // Arrange
+        var document = new Document
+        {
+            Title = "Test",
+            SourceFormat = DocumentFormat.Word,
+            Elements =
+            [
+                new HeadingElement { Level = 1, Text = "Title", Order = 0 },
+                new ParagraphElement { Text = "Content", Order = 1 }
+            ]
+        };
+
+        // Act
+        var result = await _service.ConvertAsync(document, DocumentFormat.Markdown);
+
+        // Assert
+        Assert.True(result.Success);
+        Assert.NotNull(result.OutputText);
+        Assert.Contains("# Title", result.OutputText);
+        Assert.Contains("Content", result.OutputText);
+        Assert.Equal(DocumentFormat.Markdown, result.OutputFormat);
+        Assert.Equal("text/markdown", result.ContentType);
+    }
+
+    [Fact]
+    public async Task ConvertAsync_DocumentToPdf_ReturnsPdfBytes()
+    {
+        // Arrange
+        var document = new Document
+        {
+            Title = "Test",
+            Elements =
+            [
+                new HeadingElement { Level = 1, Text = "Title", Order = 0 },
+                new ParagraphElement { Text = "Content", Order = 1 }
+            ]
+        };
+
+        // Act
+        var result = await _service.ConvertAsync(document, DocumentFormat.Pdf);
+
+        // Assert
+        Assert.True(result.Success);
+        Assert.NotNull(result.OutputBytes);
+        Assert.Equal(DocumentFormat.Pdf, result.OutputFormat);
+        Assert.Equal("application/pdf", result.ContentType);
+    }
+
+    [Fact]
+    public async Task ConvertAsync_DocumentToPlainText_ReturnsText()
+    {
+        // Arrange
+        var document = new Document
+        {
+            Elements =
+            [
+                new HeadingElement { Level = 1, Text = "Title", Order = 0 },
+                new ParagraphElement { Text = "Paragraph content.", Order = 1 }
+            ]
+        };
+
+        // Act
+        var result = await _service.ConvertAsync(document, DocumentFormat.PlainText);
+
+        // Assert
+        Assert.True(result.Success);
+        Assert.NotNull(result.OutputText);
+        Assert.Contains("Title", result.OutputText);
+        Assert.Contains("Paragraph content", result.OutputText);
+    }
+
+    [Fact]
+    public async Task ConvertAsync_DocumentToHtml_ReturnsHtml()
+    {
+        // Arrange
+        var document = new Document
+        {
+            Elements =
+            [
+                new HeadingElement { Level = 1, Text = "Title", Order = 0 },
+                new ParagraphElement { Text = "Paragraph", Order = 1 }
+            ]
+        };
+
+        // Act
+        var result = await _service.ConvertAsync(document, DocumentFormat.Html);
+
+        // Assert
+        Assert.True(result.Success);
+        Assert.NotNull(result.OutputText);
+        Assert.Contains("<h1>", result.OutputText);
+        Assert.Contains("<p>", result.OutputText);
+    }
+
+    [Fact]
+    public async Task ConvertAsync_UnsupportedFormat_ReturnsFailure()
+    {
+        // Arrange
+        var document = new Document();
+
+        // Act
+        var result = await _service.ConvertAsync(document, DocumentFormat.Unknown);
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.NotNull(result.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task ExtractTextAsync_MarkdownFile_ReturnsPlainText()
+    {
+        // Arrange
+        var markdown = "# Title\n\n**Bold** text here.";
+        using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(markdown));
+
+        // Act
+        var text = await _service.ExtractTextAsync(stream, "test.md");
+
+        // Assert
+        Assert.Contains("Title", text);
+        Assert.Contains("Bold", text);
+    }
+
+    [Fact]
+    public async Task ExtractElementsAsync_MarkdownFile_ReturnsElements()
+    {
+        // Arrange
+        var markdown = "# Heading\n\nParagraph\n\n- Item 1\n- Item 2";
+        using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(markdown));
+
+        // Act
+        var elements = await _service.ExtractElementsAsync(stream, "test.md");
+
+        // Assert
+        Assert.True(elements.Count >= 3);
+        Assert.Contains(elements, e => e is HeadingElement);
+        Assert.Contains(elements, e => e is ParagraphElement);
+        Assert.Contains(elements, e => e is ListElement);
+    }
+
+    [Fact]
+    public async Task MarkdownToPdfAsync_WithOptions_AppliesOptions()
+    {
+        // Arrange
+        var markdown = "# Test";
+        var options = new ConversionOptions
+        {
+            PageSize = PdfPageSize.Letter,
+            Orientation = PdfOrientation.Landscape
+        };
+
+        // Act
+        var bytes = await _service.MarkdownToPdfAsync(markdown, options);
+
+        // Assert
+        Assert.NotNull(bytes);
+        Assert.True(bytes.Length > 0);
+    }
+
+    [Fact]
+    public async Task MarkdownToWordAsync_WithOptions_PreservesFormatting()
+    {
+        // Arrange
+        var markdown = "**Bold** and *italic* text.";
+        var options = new ConversionOptions { PreserveFormatting = true };
+
+        // Act
+        var bytes = await _service.MarkdownToWordAsync(markdown, options);
+
+        // Assert
+        Assert.NotNull(bytes);
+        Assert.True(bytes.Length > 0);
+    }
+}

--- a/Mostlylucid.DocumentConversion.Test/DocumentModelTests.cs
+++ b/Mostlylucid.DocumentConversion.Test/DocumentModelTests.cs
@@ -1,0 +1,253 @@
+using Mostlylucid.DocumentConversion.Models;
+
+namespace Mostlylucid.DocumentConversion.Test;
+
+public class DocumentModelTests
+{
+    [Fact]
+    public void Document_GetPlainText_CombinesAllElements()
+    {
+        // Arrange
+        var document = new Document
+        {
+            Elements =
+            [
+                new HeadingElement { Text = "Title", Order = 0 },
+                new ParagraphElement { Text = "Paragraph one.", Order = 1 },
+                new ParagraphElement { Text = "Paragraph two.", Order = 2 }
+            ]
+        };
+
+        // Act
+        var text = document.GetPlainText();
+
+        // Assert
+        Assert.Contains("Title", text);
+        Assert.Contains("Paragraph one.", text);
+        Assert.Contains("Paragraph two.", text);
+    }
+
+    [Fact]
+    public void Document_GetHeadings_ReturnsOnlyHeadings()
+    {
+        // Arrange
+        var document = new Document
+        {
+            Elements =
+            [
+                new HeadingElement { Text = "H1", Level = 1, Order = 0 },
+                new ParagraphElement { Text = "Para", Order = 1 },
+                new HeadingElement { Text = "H2", Level = 2, Order = 2 }
+            ]
+        };
+
+        // Act
+        var headings = document.GetHeadings().ToList();
+
+        // Assert
+        Assert.Equal(2, headings.Count);
+        Assert.Equal("H1", headings[0].Text);
+        Assert.Equal("H2", headings[1].Text);
+    }
+
+    [Fact]
+    public void Document_GetTables_ReturnsOnlyTables()
+    {
+        // Arrange
+        var document = new Document
+        {
+            Elements =
+            [
+                new ParagraphElement { Text = "Para", Order = 0 },
+                new TableElement { Order = 1 },
+                new ParagraphElement { Text = "Another", Order = 2 }
+            ]
+        };
+
+        // Act
+        var tables = document.GetTables().ToList();
+
+        // Assert
+        Assert.Single(tables);
+    }
+
+    [Fact]
+    public void Document_GetWordCount_WithEmptyDocument_ReturnsZero()
+    {
+        // Arrange
+        var document = new Document();
+
+        // Act
+        var count = document.GetWordCount();
+
+        // Assert
+        Assert.Equal(0, count);
+    }
+
+    [Fact]
+    public void Document_GetWordCount_CountsWordsCorrectly()
+    {
+        // Arrange
+        var document = new Document
+        {
+            Elements =
+            [
+                new HeadingElement { Text = "Three Word Title", Order = 0 },
+                new ParagraphElement { Text = "One two three four five.", Order = 1 }
+            ]
+        };
+
+        // Act
+        var count = document.GetWordCount();
+
+        // Assert
+        Assert.Equal(8, count);
+    }
+
+    [Fact]
+    public void ConversionResult_SuccessText_SetsPropertiesCorrectly()
+    {
+        // Act
+        var result = ConversionResult.SuccessText("content", DocumentFormat.Markdown, "test.md");
+
+        // Assert
+        Assert.True(result.Success);
+        Assert.Equal("content", result.OutputText);
+        Assert.Equal(DocumentFormat.Markdown, result.OutputFormat);
+        Assert.Equal("test.md", result.SuggestedFileName);
+        Assert.Equal("text/markdown", result.ContentType);
+        Assert.Null(result.ErrorMessage);
+    }
+
+    [Fact]
+    public void ConversionResult_SuccessBytes_SetsPropertiesCorrectly()
+    {
+        // Arrange
+        var bytes = new byte[] { 1, 2, 3 };
+
+        // Act
+        var result = ConversionResult.SuccessBytes(bytes, DocumentFormat.Pdf, "test.pdf");
+
+        // Assert
+        Assert.True(result.Success);
+        Assert.Equal(bytes, result.OutputBytes);
+        Assert.Equal(DocumentFormat.Pdf, result.OutputFormat);
+        Assert.Equal("application/pdf", result.ContentType);
+    }
+
+    [Fact]
+    public void ConversionResult_Failure_SetsErrorMessage()
+    {
+        // Act
+        var result = ConversionResult.Failure("Something went wrong");
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.Equal("Something went wrong", result.ErrorMessage);
+        Assert.Null(result.OutputText);
+        Assert.Null(result.OutputBytes);
+    }
+
+    [Fact]
+    public void ImageElement_DataUri_GeneratesCorrectFormat()
+    {
+        // Arrange
+        var image = new ImageElement
+        {
+            Data = new byte[] { 1, 2, 3 },
+            ContentType = "image/png"
+        };
+
+        // Act
+        var dataUri = image.DataUri;
+
+        // Assert
+        Assert.NotNull(dataUri);
+        Assert.StartsWith("data:image/png;base64,", dataUri);
+    }
+
+    [Fact]
+    public void ImageElement_DataUri_WithNoData_ReturnsNull()
+    {
+        // Arrange
+        var image = new ImageElement { ContentType = "image/png" };
+
+        // Act
+        var dataUri = image.DataUri;
+
+        // Assert
+        Assert.Null(dataUri);
+    }
+
+    [Fact]
+    public void TextRun_DefaultValues_AreCorrect()
+    {
+        // Act
+        var run = new TextRun { Text = "Test" };
+
+        // Assert
+        Assert.Equal("Test", run.Text);
+        Assert.False(run.IsBold);
+        Assert.False(run.IsItalic);
+        Assert.False(run.IsUnderline);
+        Assert.False(run.IsStrikethrough);
+        Assert.False(run.IsCode);
+        Assert.Null(run.HyperlinkUrl);
+    }
+
+    [Fact]
+    public void ConversionOptions_DefaultValues_AreCorrect()
+    {
+        // Act
+        var options = new ConversionOptions();
+
+        // Assert
+        Assert.True(options.IncludeImages);
+        Assert.True(options.IncludeTables);
+        Assert.True(options.IncludeMetadata);
+        Assert.True(options.PreserveFormatting);
+        Assert.True(options.UseGitHubFlavoredMarkdown);
+        Assert.True(options.EmbedImagesAsDataUri);
+        Assert.Equal(PdfPageSize.A4, options.PageSize);
+        Assert.Equal(PdfOrientation.Portrait, options.Orientation);
+    }
+
+    [Fact]
+    public void DocumentElement_AllTypes_HaveCorrectElementType()
+    {
+        // Arrange & Act & Assert
+        Assert.Equal(DocumentElementType.Heading, new HeadingElement().ElementType);
+        Assert.Equal(DocumentElementType.Paragraph, new ParagraphElement().ElementType);
+        Assert.Equal(DocumentElementType.Table, new TableElement().ElementType);
+        Assert.Equal(DocumentElementType.List, new ListElement().ElementType);
+        Assert.Equal(DocumentElementType.ListItem, new ListItemElement().ElementType);
+        Assert.Equal(DocumentElementType.Image, new ImageElement().ElementType);
+        Assert.Equal(DocumentElementType.CodeBlock, new CodeBlockElement().ElementType);
+        Assert.Equal(DocumentElementType.BlockQuote, new BlockQuoteElement().ElementType);
+        Assert.Equal(DocumentElementType.HorizontalRule, new HorizontalRuleElement().ElementType);
+        Assert.Equal(DocumentElementType.Hyperlink, new HyperlinkElement().ElementType);
+    }
+
+    [Fact]
+    public void TableElement_DefaultHasHeaderRow_IsFalse()
+    {
+        // Act
+        var table = new TableElement();
+
+        // Assert
+        Assert.False(table.HasHeaderRow);
+        Assert.Empty(table.Rows);
+    }
+
+    [Fact]
+    public void ListElement_DefaultListType_IsBullet()
+    {
+        // Act
+        var list = new ListElement();
+
+        // Assert
+        Assert.Equal(ListType.Bullet, list.ListType);
+        Assert.Equal(1, list.StartNumber);
+        Assert.Empty(list.Items);
+    }
+}

--- a/Mostlylucid.DocumentConversion.Test/MarkdownConversionServiceTests.cs
+++ b/Mostlylucid.DocumentConversion.Test/MarkdownConversionServiceTests.cs
@@ -1,0 +1,343 @@
+using Microsoft.Extensions.Logging;
+using Mostlylucid.DocumentConversion.Models;
+using Mostlylucid.DocumentConversion.Services;
+
+namespace Mostlylucid.DocumentConversion.Test;
+
+public class MarkdownConversionServiceTests
+{
+    private readonly MarkdownConversionService _service;
+
+    public MarkdownConversionServiceTests()
+    {
+        var logger = new Mock<ILogger<MarkdownConversionService>>();
+        _service = new MarkdownConversionService(logger.Object);
+    }
+
+    [Fact]
+    public async Task ParseAsync_SimpleMarkdown_ExtractsHeading()
+    {
+        // Arrange
+        var markdown = "# Hello World\n\nThis is a paragraph.";
+
+        // Act
+        var document = await _service.ParseAsync(markdown);
+
+        // Assert
+        Assert.Equal(2, document.Elements.Count);
+        Assert.IsType<HeadingElement>(document.Elements[0]);
+        Assert.IsType<ParagraphElement>(document.Elements[1]);
+
+        var heading = (HeadingElement)document.Elements[0];
+        Assert.Equal(1, heading.Level);
+        Assert.Equal("Hello World", heading.Text);
+    }
+
+    [Fact]
+    public async Task ParseAsync_MultipleHeadingLevels_ParsesCorrectly()
+    {
+        // Arrange
+        var markdown = @"# H1
+## H2
+### H3
+#### H4
+##### H5
+###### H6";
+
+        // Act
+        var document = await _service.ParseAsync(markdown);
+
+        // Assert
+        var headings = document.GetHeadings().ToList();
+        Assert.Equal(6, headings.Count);
+        for (int i = 0; i < 6; i++)
+        {
+            Assert.Equal(i + 1, headings[i].Level);
+            Assert.Equal($"H{i + 1}", headings[i].Text);
+        }
+    }
+
+    [Fact]
+    public async Task ParseAsync_FormattedText_PreservesFormatting()
+    {
+        // Arrange
+        var markdown = "This is **bold** and *italic* text.";
+
+        // Act
+        var document = await _service.ParseAsync(markdown);
+
+        // Assert
+        var paragraph = document.Elements.OfType<ParagraphElement>().First();
+        Assert.Contains(paragraph.Runs, r => r.IsBold && r.Text == "bold");
+        Assert.Contains(paragraph.Runs, r => r.IsItalic && r.Text == "italic");
+    }
+
+    [Fact]
+    public async Task ParseAsync_CodeBlock_ExtractsLanguage()
+    {
+        // Arrange
+        var markdown = @"```csharp
+Console.WriteLine(""Hello"");
+```";
+
+        // Act
+        var document = await _service.ParseAsync(markdown);
+
+        // Assert
+        var codeBlock = document.Elements.OfType<CodeBlockElement>().FirstOrDefault();
+        Assert.NotNull(codeBlock);
+        Assert.Equal("csharp", codeBlock.Language);
+        Assert.Contains("Console.WriteLine", codeBlock.Code);
+    }
+
+    [Fact]
+    public async Task ParseAsync_BulletList_ExtractsItems()
+    {
+        // Arrange
+        var markdown = @"- Item 1
+- Item 2
+- Item 3";
+
+        // Act
+        var document = await _service.ParseAsync(markdown);
+
+        // Assert
+        var list = document.Elements.OfType<ListElement>().FirstOrDefault();
+        Assert.NotNull(list);
+        Assert.Equal(ListType.Bullet, list.ListType);
+        Assert.Equal(3, list.Items.Count);
+        Assert.Equal("Item 1", list.Items[0].Text);
+    }
+
+    [Fact]
+    public async Task ParseAsync_NumberedList_ExtractsItems()
+    {
+        // Arrange
+        var markdown = @"1. First
+2. Second
+3. Third";
+
+        // Act
+        var document = await _service.ParseAsync(markdown);
+
+        // Assert
+        var list = document.Elements.OfType<ListElement>().FirstOrDefault();
+        Assert.NotNull(list);
+        Assert.Equal(ListType.Numbered, list.ListType);
+        Assert.Equal(3, list.Items.Count);
+    }
+
+    [Fact]
+    public async Task ParseAsync_Table_ExtractsRowsAndCells()
+    {
+        // Arrange
+        var markdown = @"| Header 1 | Header 2 |
+|----------|----------|
+| Cell 1   | Cell 2   |
+| Cell 3   | Cell 4   |";
+
+        // Act
+        var document = await _service.ParseAsync(markdown);
+
+        // Assert
+        var table = document.Elements.OfType<TableElement>().FirstOrDefault();
+        Assert.NotNull(table);
+        Assert.True(table.HasHeaderRow);
+        Assert.Equal(3, table.Rows.Count); // Header + 2 data rows
+        Assert.Equal("Header 1", table.Rows[0].Cells[0].Text);
+    }
+
+    [Fact]
+    public async Task ParseAsync_BlockQuote_ExtractsText()
+    {
+        // Arrange
+        var markdown = "> This is a quote.";
+
+        // Act
+        var document = await _service.ParseAsync(markdown);
+
+        // Assert
+        var quote = document.Elements.OfType<BlockQuoteElement>().FirstOrDefault();
+        Assert.NotNull(quote);
+        Assert.Contains("This is a quote", quote.Text);
+    }
+
+    [Fact]
+    public async Task ParseAsync_HorizontalRule_Detected()
+    {
+        // Arrange
+        var markdown = "Before\n\n---\n\nAfter";
+
+        // Act
+        var document = await _service.ParseAsync(markdown);
+
+        // Assert
+        Assert.Contains(document.Elements, e => e is HorizontalRuleElement);
+    }
+
+    [Fact]
+    public async Task ToMarkdownAsync_Document_GeneratesValidMarkdown()
+    {
+        // Arrange
+        var document = new Document
+        {
+            Title = "Test Document",
+            Elements =
+            [
+                new HeadingElement { Level = 1, Text = "Title", Order = 0 },
+                new ParagraphElement { Text = "Introduction paragraph.", Order = 1 },
+                new HeadingElement { Level = 2, Text = "Section", Order = 2 },
+                new ParagraphElement { Text = "Content here.", Order = 3 }
+            ]
+        };
+
+        // Act
+        var markdown = await _service.ToMarkdownAsync(document);
+
+        // Assert
+        Assert.Contains("# Title", markdown);
+        Assert.Contains("## Section", markdown);
+        Assert.Contains("Introduction paragraph.", markdown);
+    }
+
+    [Fact]
+    public async Task ToMarkdownAsync_FormattedRuns_GeneratesCorrectSyntax()
+    {
+        // Arrange
+        var document = new Document
+        {
+            Elements =
+            [
+                new ParagraphElement
+                {
+                    Order = 0,
+                    Text = "Bold and italic",
+                    Runs =
+                    [
+                        new TextRun { Text = "Bold", IsBold = true },
+                        new TextRun { Text = " and " },
+                        new TextRun { Text = "italic", IsItalic = true }
+                    ]
+                }
+            ]
+        };
+
+        // Act
+        var markdown = await _service.ToMarkdownAsync(document);
+
+        // Assert
+        Assert.Contains("**Bold**", markdown);
+        Assert.Contains("*italic*", markdown);
+    }
+
+    [Fact]
+    public async Task ToHtmlAsync_Markdown_GeneratesHtml()
+    {
+        // Arrange
+        var markdown = "# Hello\n\nWorld";
+
+        // Act
+        var html = await _service.ToHtmlAsync(markdown);
+
+        // Assert
+        Assert.Contains("<h1>Hello</h1>", html);
+        Assert.Contains("<p>World</p>", html);
+    }
+
+    [Fact]
+    public async Task ToPlainTextAsync_FormattedMarkdown_StripsFormatting()
+    {
+        // Arrange
+        var markdown = "# Title\n\n**Bold** and *italic*.";
+
+        // Act
+        var plainText = await _service.ToPlainTextAsync(markdown);
+
+        // Assert
+        Assert.Contains("Title", plainText);
+        Assert.Contains("Bold", plainText);
+        Assert.Contains("italic", plainText);
+        Assert.DoesNotContain("**", plainText);
+        Assert.DoesNotContain("*", plainText);
+    }
+
+    [Fact]
+    public async Task ParseAsync_Links_ExtractsUrl()
+    {
+        // Arrange
+        var markdown = "Check out [this link](https://example.com).";
+
+        // Act
+        var document = await _service.ParseAsync(markdown);
+
+        // Assert
+        var paragraph = document.Elements.OfType<ParagraphElement>().First();
+        Assert.Contains(paragraph.Runs, r =>
+            r.HyperlinkUrl == "https://example.com" && r.Text == "this link");
+    }
+
+    [Fact]
+    public async Task ParseAsync_InlineCode_MarksAsCode()
+    {
+        // Arrange
+        var markdown = "Use the `Console.WriteLine()` method.";
+
+        // Act
+        var document = await _service.ParseAsync(markdown);
+
+        // Assert
+        var paragraph = document.Elements.OfType<ParagraphElement>().First();
+        Assert.Contains(paragraph.Runs, r => r.IsCode && r.Text == "Console.WriteLine()");
+    }
+
+    [Fact]
+    public async Task Document_GetWordCount_CalculatesCorrectly()
+    {
+        // Arrange
+        var markdown = "# Title\n\nOne two three four five.";
+
+        // Act
+        var document = await _service.ParseAsync(markdown);
+        var wordCount = document.GetWordCount();
+
+        // Assert
+        Assert.Equal(6, wordCount); // Title + one two three four five
+    }
+
+    [Fact]
+    public async Task ToMarkdownAsync_Table_GeneratesGfmTable()
+    {
+        // Arrange
+        var document = new Document
+        {
+            Elements =
+            [
+                new TableElement
+                {
+                    Order = 0,
+                    HasHeaderRow = true,
+                    Rows =
+                    [
+                        new Models.TableRow
+                        {
+                            IsHeader = true,
+                            Cells = [new Models.TableCell { Text = "A" }, new Models.TableCell { Text = "B" }]
+                        },
+                        new Models.TableRow
+                        {
+                            Cells = [new Models.TableCell { Text = "1" }, new Models.TableCell { Text = "2" }]
+                        }
+                    ]
+                }
+            ]
+        };
+
+        // Act
+        var markdown = await _service.ToMarkdownAsync(document);
+
+        // Assert
+        Assert.Contains("| A | B |", markdown);
+        Assert.Contains("| --- | --- |", markdown);
+        Assert.Contains("| 1 | 2 |", markdown);
+    }
+}

--- a/Mostlylucid.DocumentConversion.Test/Mostlylucid.DocumentConversion.Test.csproj
+++ b/Mostlylucid.DocumentConversion.Test/Mostlylucid.DocumentConversion.Test.csproj
@@ -1,0 +1,42 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <TargetFramework>net9.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1"/>
+    <PackageReference Include="Moq" Version="4.20.72"/>
+    <PackageReference Include="xunit" Version="2.9.3"/>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit"/>
+    <Using Include="Moq"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Mostlylucid.DocumentConversion\Mostlylucid.DocumentConversion.csproj"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="TestFiles\**\*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/Mostlylucid.DocumentConversion/Extensions/ServiceCollectionExtensions.cs
+++ b/Mostlylucid.DocumentConversion/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,47 @@
+using Microsoft.Extensions.DependencyInjection;
+using Mostlylucid.DocumentConversion.Interfaces;
+using Mostlylucid.DocumentConversion.Services;
+
+namespace Mostlylucid.DocumentConversion.Extensions;
+
+/// <summary>
+/// Extension methods for setting up document conversion services
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds document conversion services to the service collection
+    /// </summary>
+    /// <param name="services">The service collection</param>
+    /// <returns>The service collection for chaining</returns>
+    public static IServiceCollection AddDocumentConversion(this IServiceCollection services)
+    {
+        // Register individual conversion services
+        services.AddScoped<IWordDocumentService, WordDocumentService>();
+        services.AddScoped<IMarkdownConversionService, MarkdownConversionService>();
+        services.AddScoped<IPdfConversionService, PdfConversionService>();
+
+        // Register the main orchestration service
+        services.AddScoped<IDocumentConversionService, DocumentConversionService>();
+
+        return services;
+    }
+
+    /// <summary>
+    /// Adds document conversion services as singletons (for better performance in high-throughput scenarios)
+    /// </summary>
+    /// <param name="services">The service collection</param>
+    /// <returns>The service collection for chaining</returns>
+    public static IServiceCollection AddDocumentConversionSingleton(this IServiceCollection services)
+    {
+        // Register individual conversion services
+        services.AddSingleton<IWordDocumentService, WordDocumentService>();
+        services.AddSingleton<IMarkdownConversionService, MarkdownConversionService>();
+        services.AddSingleton<IPdfConversionService, PdfConversionService>();
+
+        // Register the main orchestration service
+        services.AddSingleton<IDocumentConversionService, DocumentConversionService>();
+
+        return services;
+    }
+}

--- a/Mostlylucid.DocumentConversion/Interfaces/IDocumentConversionService.cs
+++ b/Mostlylucid.DocumentConversion/Interfaces/IDocumentConversionService.cs
@@ -1,0 +1,139 @@
+using Mostlylucid.DocumentConversion.Models;
+
+namespace Mostlylucid.DocumentConversion.Interfaces;
+
+/// <summary>
+/// Main document conversion service that orchestrates all format conversions
+/// </summary>
+public interface IDocumentConversionService
+{
+    /// <summary>
+    /// Read a document from any supported format
+    /// </summary>
+    /// <param name="stream">Document stream</param>
+    /// <param name="fileName">File name (used to determine format)</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Parsed document</returns>
+    Task<Document> ReadDocumentAsync(Stream stream, string fileName, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Read a document from a file path
+    /// </summary>
+    /// <param name="filePath">Path to the document</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Parsed document</returns>
+    Task<Document> ReadDocumentAsync(string filePath, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Read a document from bytes
+    /// </summary>
+    /// <param name="data">Document data</param>
+    /// <param name="fileName">File name (used to determine format)</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Parsed document</returns>
+    Task<Document> ReadDocumentAsync(byte[] data, string fileName, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Convert a document to another format
+    /// </summary>
+    /// <param name="document">Source document</param>
+    /// <param name="targetFormat">Target format</param>
+    /// <param name="options">Conversion options</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Conversion result</returns>
+    Task<ConversionResult> ConvertAsync(Document document, DocumentFormat targetFormat, ConversionOptions? options = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Convert a document from one format to another (file to file)
+    /// </summary>
+    /// <param name="inputPath">Input file path</param>
+    /// <param name="outputPath">Output file path</param>
+    /// <param name="options">Conversion options</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Conversion result</returns>
+    Task<ConversionResult> ConvertFileAsync(string inputPath, string outputPath, ConversionOptions? options = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Convert Word document to Markdown
+    /// </summary>
+    /// <param name="wordStream">Word document stream</param>
+    /// <param name="options">Conversion options</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Markdown string</returns>
+    Task<string> WordToMarkdownAsync(Stream wordStream, ConversionOptions? options = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Convert Word document to PDF
+    /// </summary>
+    /// <param name="wordStream">Word document stream</param>
+    /// <param name="options">Conversion options</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>PDF bytes</returns>
+    Task<byte[]> WordToPdfAsync(Stream wordStream, ConversionOptions? options = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Convert Markdown to Word document
+    /// </summary>
+    /// <param name="markdown">Markdown content</param>
+    /// <param name="options">Conversion options</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Word document bytes</returns>
+    Task<byte[]> MarkdownToWordAsync(string markdown, ConversionOptions? options = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Convert Markdown to PDF
+    /// </summary>
+    /// <param name="markdown">Markdown content</param>
+    /// <param name="options">Conversion options</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>PDF bytes</returns>
+    Task<byte[]> MarkdownToPdfAsync(string markdown, ConversionOptions? options = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Extract all elements from a document
+    /// </summary>
+    /// <param name="stream">Document stream</param>
+    /// <param name="fileName">File name</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>List of document elements</returns>
+    Task<List<DocumentElement>> ExtractElementsAsync(Stream stream, string fileName, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Extract text from a document
+    /// </summary>
+    /// <param name="stream">Document stream</param>
+    /// <param name="fileName">File name</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Plain text content</returns>
+    Task<string> ExtractTextAsync(Stream stream, string fileName, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Extract images from a document
+    /// </summary>
+    /// <param name="stream">Document stream</param>
+    /// <param name="fileName">File name</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>List of images</returns>
+    Task<List<ImageElement>> ExtractImagesAsync(Stream stream, string fileName, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Determine the document format from a file name
+    /// </summary>
+    /// <param name="fileName">File name or path</param>
+    /// <returns>Detected format</returns>
+    DocumentFormat DetectFormat(string fileName);
+
+    /// <summary>
+    /// Check if a format is supported for reading
+    /// </summary>
+    /// <param name="format">Format to check</param>
+    /// <returns>True if supported</returns>
+    bool CanRead(DocumentFormat format);
+
+    /// <summary>
+    /// Check if a format is supported for writing
+    /// </summary>
+    /// <param name="format">Format to check</param>
+    /// <returns>True if supported</returns>
+    bool CanWrite(DocumentFormat format);
+}

--- a/Mostlylucid.DocumentConversion/Interfaces/IMarkdownConversionService.cs
+++ b/Mostlylucid.DocumentConversion/Interfaces/IMarkdownConversionService.cs
@@ -1,0 +1,60 @@
+using Mostlylucid.DocumentConversion.Models;
+
+namespace Mostlylucid.DocumentConversion.Interfaces;
+
+/// <summary>
+/// Service for converting to and from Markdown format
+/// </summary>
+public interface IMarkdownConversionService
+{
+    /// <summary>
+    /// Parse Markdown content into a Document model
+    /// </summary>
+    /// <param name="markdown">Markdown content</param>
+    /// <param name="fileName">Optional file name for metadata</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Parsed document</returns>
+    Task<Document> ParseAsync(string markdown, string? fileName = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Read Markdown from a file
+    /// </summary>
+    /// <param name="filePath">Path to the .md file</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Parsed document</returns>
+    Task<Document> ReadAsync(string filePath, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Convert a Document to Markdown format
+    /// </summary>
+    /// <param name="document">Document to convert</param>
+    /// <param name="options">Conversion options</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Markdown string</returns>
+    Task<string> ToMarkdownAsync(Document document, ConversionOptions? options = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Convert Markdown to HTML
+    /// </summary>
+    /// <param name="markdown">Markdown content</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>HTML string</returns>
+    Task<string> ToHtmlAsync(string markdown, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Convert a Document to HTML
+    /// </summary>
+    /// <param name="document">Document to convert</param>
+    /// <param name="options">Conversion options</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>HTML string</returns>
+    Task<string> ToHtmlAsync(Document document, ConversionOptions? options = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Convert Markdown to plain text
+    /// </summary>
+    /// <param name="markdown">Markdown content</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Plain text string</returns>
+    Task<string> ToPlainTextAsync(string markdown, CancellationToken cancellationToken = default);
+}

--- a/Mostlylucid.DocumentConversion/Interfaces/IPdfConversionService.cs
+++ b/Mostlylucid.DocumentConversion/Interfaces/IPdfConversionService.cs
@@ -1,0 +1,45 @@
+using Mostlylucid.DocumentConversion.Models;
+
+namespace Mostlylucid.DocumentConversion.Interfaces;
+
+/// <summary>
+/// Service for generating PDF documents
+/// </summary>
+public interface IPdfConversionService
+{
+    /// <summary>
+    /// Convert a Document to PDF format
+    /// </summary>
+    /// <param name="document">Document to convert</param>
+    /// <param name="options">Conversion options</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>PDF as bytes</returns>
+    Task<byte[]> ToPdfAsync(Document document, ConversionOptions? options = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Convert a Document to PDF and save to file
+    /// </summary>
+    /// <param name="document">Document to convert</param>
+    /// <param name="filePath">Output file path</param>
+    /// <param name="options">Conversion options</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    Task ToPdfFileAsync(Document document, string filePath, ConversionOptions? options = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Convert Markdown content directly to PDF
+    /// </summary>
+    /// <param name="markdown">Markdown content</param>
+    /// <param name="options">Conversion options</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>PDF as bytes</returns>
+    Task<byte[]> MarkdownToPdfAsync(string markdown, ConversionOptions? options = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Convert HTML content to PDF
+    /// </summary>
+    /// <param name="html">HTML content</param>
+    /// <param name="options">Conversion options</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>PDF as bytes</returns>
+    Task<byte[]> HtmlToPdfAsync(string html, ConversionOptions? options = null, CancellationToken cancellationToken = default);
+}

--- a/Mostlylucid.DocumentConversion/Interfaces/IWordDocumentService.cs
+++ b/Mostlylucid.DocumentConversion/Interfaces/IWordDocumentService.cs
@@ -1,0 +1,69 @@
+using Mostlylucid.DocumentConversion.Models;
+
+namespace Mostlylucid.DocumentConversion.Interfaces;
+
+/// <summary>
+/// Service for reading and writing Word documents (.docx)
+/// </summary>
+public interface IWordDocumentService
+{
+    /// <summary>
+    /// Read a Word document from a file path
+    /// </summary>
+    /// <param name="filePath">Path to the .docx file</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Parsed document</returns>
+    Task<Document> ReadAsync(string filePath, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Read a Word document from a stream
+    /// </summary>
+    /// <param name="stream">Stream containing the .docx data</param>
+    /// <param name="fileName">Optional file name for metadata</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Parsed document</returns>
+    Task<Document> ReadAsync(Stream stream, string? fileName = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Read a Word document from bytes
+    /// </summary>
+    /// <param name="data">Byte array containing the .docx data</param>
+    /// <param name="fileName">Optional file name for metadata</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Parsed document</returns>
+    Task<Document> ReadAsync(byte[] data, string? fileName = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Create a Word document from a Document model
+    /// </summary>
+    /// <param name="document">Document to convert</param>
+    /// <param name="options">Conversion options</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Word document as bytes</returns>
+    Task<byte[]> CreateAsync(Document document, ConversionOptions? options = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Write a Word document to a file
+    /// </summary>
+    /// <param name="document">Document to write</param>
+    /// <param name="filePath">Output file path</param>
+    /// <param name="options">Conversion options</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    Task WriteAsync(Document document, string filePath, ConversionOptions? options = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Extract all text from a Word document
+    /// </summary>
+    /// <param name="stream">Stream containing the .docx data</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Plain text content</returns>
+    Task<string> ExtractTextAsync(Stream stream, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Extract all images from a Word document
+    /// </summary>
+    /// <param name="stream">Stream containing the .docx data</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>List of extracted images</returns>
+    Task<List<ImageElement>> ExtractImagesAsync(Stream stream, CancellationToken cancellationToken = default);
+}

--- a/Mostlylucid.DocumentConversion/Models/Document.cs
+++ b/Mostlylucid.DocumentConversion/Models/Document.cs
@@ -1,0 +1,338 @@
+namespace Mostlylucid.DocumentConversion.Models;
+
+/// <summary>
+/// Represents a complete document with metadata and elements
+/// </summary>
+public class Document
+{
+    /// <summary>
+    /// Document title
+    /// </summary>
+    public string? Title { get; set; }
+
+    /// <summary>
+    /// Document author
+    /// </summary>
+    public string? Author { get; set; }
+
+    /// <summary>
+    /// Document subject/description
+    /// </summary>
+    public string? Subject { get; set; }
+
+    /// <summary>
+    /// Document keywords/tags
+    /// </summary>
+    public List<string> Keywords { get; set; } = [];
+
+    /// <summary>
+    /// Document creation date
+    /// </summary>
+    public DateTime? CreatedDate { get; set; }
+
+    /// <summary>
+    /// Document last modified date
+    /// </summary>
+    public DateTime? ModifiedDate { get; set; }
+
+    /// <summary>
+    /// Original file name
+    /// </summary>
+    public string? FileName { get; set; }
+
+    /// <summary>
+    /// Source format of the document
+    /// </summary>
+    public DocumentFormat SourceFormat { get; set; }
+
+    /// <summary>
+    /// All document elements in order
+    /// </summary>
+    public List<DocumentElement> Elements { get; set; } = [];
+
+    /// <summary>
+    /// Embedded images extracted from the document
+    /// </summary>
+    public List<ImageElement> Images { get; set; } = [];
+
+    /// <summary>
+    /// Custom properties/metadata
+    /// </summary>
+    public Dictionary<string, string> CustomProperties { get; set; } = new();
+
+    /// <summary>
+    /// Get plain text representation of the document
+    /// </summary>
+    public string GetPlainText()
+    {
+        var lines = new List<string>();
+
+        foreach (var element in Elements)
+        {
+            var text = element switch
+            {
+                HeadingElement h => h.Text,
+                ParagraphElement p => p.Text,
+                ListElement l => string.Join("\n", l.Items.Select(i => $"• {i.Text}")),
+                CodeBlockElement c => c.Code,
+                BlockQuoteElement b => $"> {b.Text}",
+                TableElement t => GetTableText(t),
+                _ => null
+            };
+
+            if (!string.IsNullOrWhiteSpace(text))
+            {
+                lines.Add(text);
+            }
+        }
+
+        return string.Join("\n\n", lines);
+    }
+
+    private static string GetTableText(TableElement table)
+    {
+        var rows = table.Rows.Select(r =>
+            string.Join(" | ", r.Cells.Select(c => c.Text)));
+        return string.Join("\n", rows);
+    }
+
+    /// <summary>
+    /// Get all headings from the document
+    /// </summary>
+    public IEnumerable<HeadingElement> GetHeadings()
+    {
+        return Elements.OfType<HeadingElement>();
+    }
+
+    /// <summary>
+    /// Get all paragraphs from the document
+    /// </summary>
+    public IEnumerable<ParagraphElement> GetParagraphs()
+    {
+        return Elements.OfType<ParagraphElement>();
+    }
+
+    /// <summary>
+    /// Get all tables from the document
+    /// </summary>
+    public IEnumerable<TableElement> GetTables()
+    {
+        return Elements.OfType<TableElement>();
+    }
+
+    /// <summary>
+    /// Get all lists from the document
+    /// </summary>
+    public IEnumerable<ListElement> GetLists()
+    {
+        return Elements.OfType<ListElement>();
+    }
+
+    /// <summary>
+    /// Get all code blocks from the document
+    /// </summary>
+    public IEnumerable<CodeBlockElement> GetCodeBlocks()
+    {
+        return Elements.OfType<CodeBlockElement>();
+    }
+
+    /// <summary>
+    /// Get word count of the document
+    /// </summary>
+    public int GetWordCount()
+    {
+        var text = GetPlainText();
+        return string.IsNullOrWhiteSpace(text)
+            ? 0
+            : text.Split([' ', '\n', '\r', '\t'], StringSplitOptions.RemoveEmptyEntries).Length;
+    }
+}
+
+/// <summary>
+/// Supported document formats
+/// </summary>
+public enum DocumentFormat
+{
+    Unknown,
+    Word,       // .docx
+    WordLegacy, // .doc (not supported for full processing)
+    Markdown,   // .md
+    Pdf,        // .pdf (output only)
+    Html,       // .html
+    PlainText   // .txt
+}
+
+/// <summary>
+/// Result of a document conversion operation
+/// </summary>
+public class ConversionResult
+{
+    /// <summary>
+    /// Whether the conversion was successful
+    /// </summary>
+    public bool Success { get; set; }
+
+    /// <summary>
+    /// Error message if conversion failed
+    /// </summary>
+    public string? ErrorMessage { get; set; }
+
+    /// <summary>
+    /// Converted content as bytes (for binary formats like PDF)
+    /// </summary>
+    public byte[]? OutputBytes { get; set; }
+
+    /// <summary>
+    /// Converted content as string (for text formats like Markdown)
+    /// </summary>
+    public string? OutputText { get; set; }
+
+    /// <summary>
+    /// Output format
+    /// </summary>
+    public DocumentFormat OutputFormat { get; set; }
+
+    /// <summary>
+    /// Suggested file name for the output
+    /// </summary>
+    public string? SuggestedFileName { get; set; }
+
+    /// <summary>
+    /// Content type/MIME type for the output
+    /// </summary>
+    public string? ContentType { get; set; }
+
+    /// <summary>
+    /// Warnings encountered during conversion
+    /// </summary>
+    public List<string> Warnings { get; set; } = [];
+
+    /// <summary>
+    /// Create a successful result with text output
+    /// </summary>
+    public static ConversionResult SuccessText(string text, DocumentFormat format, string? fileName = null)
+    {
+        return new ConversionResult
+        {
+            Success = true,
+            OutputText = text,
+            OutputFormat = format,
+            SuggestedFileName = fileName,
+            ContentType = GetContentType(format)
+        };
+    }
+
+    /// <summary>
+    /// Create a successful result with binary output
+    /// </summary>
+    public static ConversionResult SuccessBytes(byte[] bytes, DocumentFormat format, string? fileName = null)
+    {
+        return new ConversionResult
+        {
+            Success = true,
+            OutputBytes = bytes,
+            OutputFormat = format,
+            SuggestedFileName = fileName,
+            ContentType = GetContentType(format)
+        };
+    }
+
+    /// <summary>
+    /// Create a failed result
+    /// </summary>
+    public static ConversionResult Failure(string errorMessage)
+    {
+        return new ConversionResult
+        {
+            Success = false,
+            ErrorMessage = errorMessage
+        };
+    }
+
+    private static string GetContentType(DocumentFormat format) => format switch
+    {
+        DocumentFormat.Word => "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        DocumentFormat.Pdf => "application/pdf",
+        DocumentFormat.Markdown => "text/markdown",
+        DocumentFormat.Html => "text/html",
+        DocumentFormat.PlainText => "text/plain",
+        _ => "application/octet-stream"
+    };
+}
+
+/// <summary>
+/// Options for document conversion
+/// </summary>
+public class ConversionOptions
+{
+    /// <summary>
+    /// Include images in the output
+    /// </summary>
+    public bool IncludeImages { get; set; } = true;
+
+    /// <summary>
+    /// Include tables in the output
+    /// </summary>
+    public bool IncludeTables { get; set; } = true;
+
+    /// <summary>
+    /// Include document metadata in the output
+    /// </summary>
+    public bool IncludeMetadata { get; set; } = true;
+
+    /// <summary>
+    /// Preserve formatting (bold, italic, etc.)
+    /// </summary>
+    public bool PreserveFormatting { get; set; } = true;
+
+    /// <summary>
+    /// For PDF output: page size
+    /// </summary>
+    public PdfPageSize PageSize { get; set; } = PdfPageSize.A4;
+
+    /// <summary>
+    /// For PDF output: page orientation
+    /// </summary>
+    public PdfOrientation Orientation { get; set; } = PdfOrientation.Portrait;
+
+    /// <summary>
+    /// For Markdown output: use GitHub Flavored Markdown
+    /// </summary>
+    public bool UseGitHubFlavoredMarkdown { get; set; } = true;
+
+    /// <summary>
+    /// For images: embed as base64 data URIs
+    /// </summary>
+    public bool EmbedImagesAsDataUri { get; set; } = true;
+
+    /// <summary>
+    /// For images: output directory (if not embedding)
+    /// </summary>
+    public string? ImageOutputDirectory { get; set; }
+
+    /// <summary>
+    /// Custom CSS for HTML output
+    /// </summary>
+    public string? CustomCss { get; set; }
+}
+
+/// <summary>
+/// PDF page sizes
+/// </summary>
+public enum PdfPageSize
+{
+    A4,
+    A3,
+    A5,
+    Letter,
+    Legal
+}
+
+/// <summary>
+/// PDF page orientations
+/// </summary>
+public enum PdfOrientation
+{
+    Portrait,
+    Landscape
+}

--- a/Mostlylucid.DocumentConversion/Models/DocumentElement.cs
+++ b/Mostlylucid.DocumentConversion/Models/DocumentElement.cs
@@ -1,0 +1,420 @@
+namespace Mostlylucid.DocumentConversion.Models;
+
+/// <summary>
+/// Base class for all document elements
+/// </summary>
+public abstract class DocumentElement
+{
+    /// <summary>
+    /// Unique identifier for the element
+    /// </summary>
+    public string Id { get; set; } = Guid.NewGuid().ToString("N");
+
+    /// <summary>
+    /// Type of the document element
+    /// </summary>
+    public abstract DocumentElementType ElementType { get; }
+
+    /// <summary>
+    /// Order/position of the element in the document
+    /// </summary>
+    public int Order { get; set; }
+}
+
+/// <summary>
+/// Types of document elements that can be extracted
+/// </summary>
+public enum DocumentElementType
+{
+    Paragraph,
+    Heading,
+    Table,
+    Image,
+    List,
+    ListItem,
+    CodeBlock,
+    BlockQuote,
+    HorizontalRule,
+    Hyperlink,
+    Run,
+    Unknown
+}
+
+/// <summary>
+/// Represents a paragraph element
+/// </summary>
+public class ParagraphElement : DocumentElement
+{
+    public override DocumentElementType ElementType => DocumentElementType.Paragraph;
+
+    /// <summary>
+    /// Text content of the paragraph
+    /// </summary>
+    public string Text { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Child runs with formatting
+    /// </summary>
+    public List<TextRun> Runs { get; set; } = [];
+
+    /// <summary>
+    /// Paragraph style name (e.g., "Normal", "Heading 1")
+    /// </summary>
+    public string? StyleName { get; set; }
+
+    /// <summary>
+    /// Paragraph alignment
+    /// </summary>
+    public TextAlignment Alignment { get; set; } = TextAlignment.Left;
+}
+
+/// <summary>
+/// Represents a heading element
+/// </summary>
+public class HeadingElement : DocumentElement
+{
+    public override DocumentElementType ElementType => DocumentElementType.Heading;
+
+    /// <summary>
+    /// Heading level (1-6)
+    /// </summary>
+    public int Level { get; set; } = 1;
+
+    /// <summary>
+    /// Heading text content
+    /// </summary>
+    public string Text { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Child runs with formatting
+    /// </summary>
+    public List<TextRun> Runs { get; set; } = [];
+}
+
+/// <summary>
+/// Represents formatted text within a paragraph or heading
+/// </summary>
+public class TextRun
+{
+    /// <summary>
+    /// The text content
+    /// </summary>
+    public string Text { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Is the text bold
+    /// </summary>
+    public bool IsBold { get; set; }
+
+    /// <summary>
+    /// Is the text italic
+    /// </summary>
+    public bool IsItalic { get; set; }
+
+    /// <summary>
+    /// Is the text underlined
+    /// </summary>
+    public bool IsUnderline { get; set; }
+
+    /// <summary>
+    /// Is the text strikethrough
+    /// </summary>
+    public bool IsStrikethrough { get; set; }
+
+    /// <summary>
+    /// Is the text superscript
+    /// </summary>
+    public bool IsSuperscript { get; set; }
+
+    /// <summary>
+    /// Is the text subscript
+    /// </summary>
+    public bool IsSubscript { get; set; }
+
+    /// <summary>
+    /// Is the text code/monospace
+    /// </summary>
+    public bool IsCode { get; set; }
+
+    /// <summary>
+    /// Font name if specified
+    /// </summary>
+    public string? FontName { get; set; }
+
+    /// <summary>
+    /// Font size in points if specified
+    /// </summary>
+    public double? FontSize { get; set; }
+
+    /// <summary>
+    /// Text color in hex format (e.g., "#FF0000")
+    /// </summary>
+    public string? Color { get; set; }
+
+    /// <summary>
+    /// Highlight/background color
+    /// </summary>
+    public string? HighlightColor { get; set; }
+
+    /// <summary>
+    /// Hyperlink URL if this run is a link
+    /// </summary>
+    public string? HyperlinkUrl { get; set; }
+}
+
+/// <summary>
+/// Text alignment options
+/// </summary>
+public enum TextAlignment
+{
+    Left,
+    Center,
+    Right,
+    Justify
+}
+
+/// <summary>
+/// Represents a table element
+/// </summary>
+public class TableElement : DocumentElement
+{
+    public override DocumentElementType ElementType => DocumentElementType.Table;
+
+    /// <summary>
+    /// Table rows
+    /// </summary>
+    public List<TableRow> Rows { get; set; } = [];
+
+    /// <summary>
+    /// Whether the first row is a header
+    /// </summary>
+    public bool HasHeaderRow { get; set; }
+
+    /// <summary>
+    /// Table width in percentage or twips
+    /// </summary>
+    public double? Width { get; set; }
+}
+
+/// <summary>
+/// Represents a table row
+/// </summary>
+public class TableRow
+{
+    /// <summary>
+    /// Cells in the row
+    /// </summary>
+    public List<TableCell> Cells { get; set; } = [];
+
+    /// <summary>
+    /// Whether this is a header row
+    /// </summary>
+    public bool IsHeader { get; set; }
+}
+
+/// <summary>
+/// Represents a table cell
+/// </summary>
+public class TableCell
+{
+    /// <summary>
+    /// Cell content as document elements
+    /// </summary>
+    public List<DocumentElement> Content { get; set; } = [];
+
+    /// <summary>
+    /// Plain text content
+    /// </summary>
+    public string Text { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Number of columns this cell spans
+    /// </summary>
+    public int ColumnSpan { get; set; } = 1;
+
+    /// <summary>
+    /// Number of rows this cell spans
+    /// </summary>
+    public int RowSpan { get; set; } = 1;
+
+    /// <summary>
+    /// Cell background color
+    /// </summary>
+    public string? BackgroundColor { get; set; }
+}
+
+/// <summary>
+/// Represents an image element
+/// </summary>
+public class ImageElement : DocumentElement
+{
+    public override DocumentElementType ElementType => DocumentElementType.Image;
+
+    /// <summary>
+    /// Image data as bytes
+    /// </summary>
+    public byte[]? Data { get; set; }
+
+    /// <summary>
+    /// Image content type (e.g., "image/png", "image/jpeg")
+    /// </summary>
+    public string? ContentType { get; set; }
+
+    /// <summary>
+    /// Image file name
+    /// </summary>
+    public string? FileName { get; set; }
+
+    /// <summary>
+    /// Alt text for the image
+    /// </summary>
+    public string? AltText { get; set; }
+
+    /// <summary>
+    /// Image width in pixels
+    /// </summary>
+    public int? Width { get; set; }
+
+    /// <summary>
+    /// Image height in pixels
+    /// </summary>
+    public int? Height { get; set; }
+
+    /// <summary>
+    /// Base64 encoded data URI
+    /// </summary>
+    public string? DataUri => Data != null && ContentType != null
+        ? $"data:{ContentType};base64,{Convert.ToBase64String(Data)}"
+        : null;
+}
+
+/// <summary>
+/// Represents a list element
+/// </summary>
+public class ListElement : DocumentElement
+{
+    public override DocumentElementType ElementType => DocumentElementType.List;
+
+    /// <summary>
+    /// List items
+    /// </summary>
+    public List<ListItemElement> Items { get; set; } = [];
+
+    /// <summary>
+    /// Type of list
+    /// </summary>
+    public ListType ListType { get; set; } = ListType.Bullet;
+
+    /// <summary>
+    /// Starting number for ordered lists
+    /// </summary>
+    public int StartNumber { get; set; } = 1;
+}
+
+/// <summary>
+/// Represents a list item
+/// </summary>
+public class ListItemElement : DocumentElement
+{
+    public override DocumentElementType ElementType => DocumentElementType.ListItem;
+
+    /// <summary>
+    /// Item text content
+    /// </summary>
+    public string Text { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Child runs with formatting
+    /// </summary>
+    public List<TextRun> Runs { get; set; } = [];
+
+    /// <summary>
+    /// Nesting level (0-based)
+    /// </summary>
+    public int Level { get; set; }
+
+    /// <summary>
+    /// Nested child list (for nested lists)
+    /// </summary>
+    public ListElement? NestedList { get; set; }
+}
+
+/// <summary>
+/// Type of list
+/// </summary>
+public enum ListType
+{
+    Bullet,
+    Numbered,
+    LetterLower,
+    LetterUpper,
+    RomanLower,
+    RomanUpper
+}
+
+/// <summary>
+/// Represents a code block element
+/// </summary>
+public class CodeBlockElement : DocumentElement
+{
+    public override DocumentElementType ElementType => DocumentElementType.CodeBlock;
+
+    /// <summary>
+    /// Code content
+    /// </summary>
+    public string Code { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Programming language (for syntax highlighting)
+    /// </summary>
+    public string? Language { get; set; }
+}
+
+/// <summary>
+/// Represents a block quote element
+/// </summary>
+public class BlockQuoteElement : DocumentElement
+{
+    public override DocumentElementType ElementType => DocumentElementType.BlockQuote;
+
+    /// <summary>
+    /// Quote content as document elements
+    /// </summary>
+    public List<DocumentElement> Content { get; set; } = [];
+
+    /// <summary>
+    /// Plain text content
+    /// </summary>
+    public string Text { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Represents a horizontal rule/divider
+/// </summary>
+public class HorizontalRuleElement : DocumentElement
+{
+    public override DocumentElementType ElementType => DocumentElementType.HorizontalRule;
+}
+
+/// <summary>
+/// Represents a hyperlink element
+/// </summary>
+public class HyperlinkElement : DocumentElement
+{
+    public override DocumentElementType ElementType => DocumentElementType.Hyperlink;
+
+    /// <summary>
+    /// Link URL
+    /// </summary>
+    public string Url { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Link text
+    /// </summary>
+    public string Text { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Link title/tooltip
+    /// </summary>
+    public string? Title { get; set; }
+}

--- a/Mostlylucid.DocumentConversion/Mostlylucid.DocumentConversion.csproj
+++ b/Mostlylucid.DocumentConversion/Mostlylucid.DocumentConversion.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Word Document Processing (OpenXML) -->
+    <PackageReference Include="DocumentFormat.OpenXml" Version="3.2.0" />
+
+    <!-- Markdown Processing -->
+    <PackageReference Include="Markdig" Version="0.43.0" />
+
+    <!-- PDF Generation -->
+    <PackageReference Include="QuestPDF" Version="2024.12.3" />
+
+    <!-- Logging -->
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+
+    <!-- DI Extensions -->
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/Mostlylucid.DocumentConversion/Services/DocumentConversionService.cs
+++ b/Mostlylucid.DocumentConversion/Services/DocumentConversionService.cs
@@ -1,0 +1,275 @@
+using Microsoft.Extensions.Logging;
+using Mostlylucid.DocumentConversion.Interfaces;
+using Mostlylucid.DocumentConversion.Models;
+
+namespace Mostlylucid.DocumentConversion.Services;
+
+/// <summary>
+/// Main document conversion service that orchestrates all format conversions
+/// </summary>
+public class DocumentConversionService : IDocumentConversionService
+{
+    private readonly ILogger<DocumentConversionService> _logger;
+    private readonly IWordDocumentService _wordService;
+    private readonly IMarkdownConversionService _markdownService;
+    private readonly IPdfConversionService _pdfService;
+
+    private static readonly Dictionary<string, DocumentFormat> ExtensionMap = new(StringComparer.OrdinalIgnoreCase)
+    {
+        { ".docx", DocumentFormat.Word },
+        { ".doc", DocumentFormat.WordLegacy },
+        { ".md", DocumentFormat.Markdown },
+        { ".markdown", DocumentFormat.Markdown },
+        { ".pdf", DocumentFormat.Pdf },
+        { ".html", DocumentFormat.Html },
+        { ".htm", DocumentFormat.Html },
+        { ".txt", DocumentFormat.PlainText }
+    };
+
+    private static readonly HashSet<DocumentFormat> ReadableFormats =
+    [
+        DocumentFormat.Word,
+        DocumentFormat.Markdown,
+        DocumentFormat.PlainText
+    ];
+
+    private static readonly HashSet<DocumentFormat> WritableFormats =
+    [
+        DocumentFormat.Word,
+        DocumentFormat.Markdown,
+        DocumentFormat.Pdf,
+        DocumentFormat.Html,
+        DocumentFormat.PlainText
+    ];
+
+    public DocumentConversionService(
+        ILogger<DocumentConversionService> logger,
+        IWordDocumentService wordService,
+        IMarkdownConversionService markdownService,
+        IPdfConversionService pdfService)
+    {
+        _logger = logger;
+        _wordService = wordService;
+        _markdownService = markdownService;
+        _pdfService = pdfService;
+    }
+
+    public async Task<Document> ReadDocumentAsync(string filePath, CancellationToken cancellationToken = default)
+    {
+        var format = DetectFormat(filePath);
+        await using var stream = File.OpenRead(filePath);
+        return await ReadDocumentAsync(stream, Path.GetFileName(filePath), cancellationToken);
+    }
+
+    public async Task<Document> ReadDocumentAsync(byte[] data, string fileName, CancellationToken cancellationToken = default)
+    {
+        using var stream = new MemoryStream(data);
+        return await ReadDocumentAsync(stream, fileName, cancellationToken);
+    }
+
+    public async Task<Document> ReadDocumentAsync(Stream stream, string fileName, CancellationToken cancellationToken = default)
+    {
+        var format = DetectFormat(fileName);
+
+        _logger.LogInformation("Reading document {FileName} as {Format}", fileName, format);
+
+        return format switch
+        {
+            DocumentFormat.Word => await _wordService.ReadAsync(stream, fileName, cancellationToken),
+            DocumentFormat.Markdown => await ReadMarkdownFromStreamAsync(stream, fileName, cancellationToken),
+            DocumentFormat.PlainText => await ReadPlainTextFromStreamAsync(stream, fileName, cancellationToken),
+            DocumentFormat.WordLegacy => throw new NotSupportedException("Legacy .doc format is not supported. Please convert to .docx first."),
+            DocumentFormat.Pdf => throw new NotSupportedException("PDF reading is not supported. PDF is an output-only format."),
+            _ => throw new NotSupportedException($"Format {format} is not supported for reading.")
+        };
+    }
+
+    public async Task<ConversionResult> ConvertAsync(Document document, DocumentFormat targetFormat, ConversionOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("Converting document from {Source} to {Target}", document.SourceFormat, targetFormat);
+
+        try
+        {
+            return targetFormat switch
+            {
+                DocumentFormat.Word => await ConvertToWordAsync(document, options, cancellationToken),
+                DocumentFormat.Markdown => await ConvertToMarkdownAsync(document, options, cancellationToken),
+                DocumentFormat.Pdf => await ConvertToPdfAsync(document, options, cancellationToken),
+                DocumentFormat.Html => await ConvertToHtmlAsync(document, options, cancellationToken),
+                DocumentFormat.PlainText => ConvertToPlainText(document),
+                _ => ConversionResult.Failure($"Target format {targetFormat} is not supported.")
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to convert document to {Format}", targetFormat);
+            return ConversionResult.Failure($"Conversion failed: {ex.Message}");
+        }
+    }
+
+    public async Task<ConversionResult> ConvertFileAsync(string inputPath, string outputPath, ConversionOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        var document = await ReadDocumentAsync(inputPath, cancellationToken);
+        var targetFormat = DetectFormat(outputPath);
+
+        var result = await ConvertAsync(document, targetFormat, options, cancellationToken);
+
+        if (result.Success)
+        {
+            if (result.OutputBytes != null)
+            {
+                await File.WriteAllBytesAsync(outputPath, result.OutputBytes, cancellationToken);
+            }
+            else if (result.OutputText != null)
+            {
+                await File.WriteAllTextAsync(outputPath, result.OutputText, cancellationToken);
+            }
+
+            result.SuggestedFileName = Path.GetFileName(outputPath);
+            _logger.LogInformation("Successfully converted {Input} to {Output}", inputPath, outputPath);
+        }
+
+        return result;
+    }
+
+    public async Task<string> WordToMarkdownAsync(Stream wordStream, ConversionOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        var document = await _wordService.ReadAsync(wordStream, null, cancellationToken);
+        return await _markdownService.ToMarkdownAsync(document, options, cancellationToken);
+    }
+
+    public async Task<byte[]> WordToPdfAsync(Stream wordStream, ConversionOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        var document = await _wordService.ReadAsync(wordStream, null, cancellationToken);
+        return await _pdfService.ToPdfAsync(document, options, cancellationToken);
+    }
+
+    public async Task<byte[]> MarkdownToWordAsync(string markdown, ConversionOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        var document = await _markdownService.ParseAsync(markdown, null, cancellationToken);
+        return await _wordService.CreateAsync(document, options, cancellationToken);
+    }
+
+    public async Task<byte[]> MarkdownToPdfAsync(string markdown, ConversionOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        return await _pdfService.MarkdownToPdfAsync(markdown, options, cancellationToken);
+    }
+
+    public async Task<List<DocumentElement>> ExtractElementsAsync(Stream stream, string fileName, CancellationToken cancellationToken = default)
+    {
+        var document = await ReadDocumentAsync(stream, fileName, cancellationToken);
+        return document.Elements;
+    }
+
+    public async Task<string> ExtractTextAsync(Stream stream, string fileName, CancellationToken cancellationToken = default)
+    {
+        var format = DetectFormat(fileName);
+
+        if (format == DocumentFormat.Word)
+        {
+            return await _wordService.ExtractTextAsync(stream, cancellationToken);
+        }
+
+        var document = await ReadDocumentAsync(stream, fileName, cancellationToken);
+        return document.GetPlainText();
+    }
+
+    public async Task<List<ImageElement>> ExtractImagesAsync(Stream stream, string fileName, CancellationToken cancellationToken = default)
+    {
+        var format = DetectFormat(fileName);
+
+        if (format == DocumentFormat.Word)
+        {
+            return await _wordService.ExtractImagesAsync(stream, cancellationToken);
+        }
+
+        var document = await ReadDocumentAsync(stream, fileName, cancellationToken);
+        return document.Images;
+    }
+
+    public DocumentFormat DetectFormat(string fileName)
+    {
+        var extension = Path.GetExtension(fileName);
+        return ExtensionMap.TryGetValue(extension, out var format) ? format : DocumentFormat.Unknown;
+    }
+
+    public bool CanRead(DocumentFormat format) => ReadableFormats.Contains(format);
+
+    public bool CanWrite(DocumentFormat format) => WritableFormats.Contains(format);
+
+    private async Task<Document> ReadMarkdownFromStreamAsync(Stream stream, string? fileName, CancellationToken cancellationToken)
+    {
+        using var reader = new StreamReader(stream);
+        var content = await reader.ReadToEndAsync(cancellationToken);
+        return await _markdownService.ParseAsync(content, fileName, cancellationToken);
+    }
+
+    private async Task<Document> ReadPlainTextFromStreamAsync(Stream stream, string? fileName, CancellationToken cancellationToken)
+    {
+        using var reader = new StreamReader(stream);
+        var content = await reader.ReadToEndAsync(cancellationToken);
+
+        return new Document
+        {
+            FileName = fileName,
+            SourceFormat = DocumentFormat.PlainText,
+            Elements = content.Split(["\n\n", "\r\n\r\n"], StringSplitOptions.RemoveEmptyEntries)
+                .Select((text, index) => new ParagraphElement
+                {
+                    Order = index,
+                    Text = text.Trim()
+                } as DocumentElement)
+                .ToList()
+        };
+    }
+
+    private async Task<ConversionResult> ConvertToWordAsync(Document document, ConversionOptions? options, CancellationToken cancellationToken)
+    {
+        var bytes = await _wordService.CreateAsync(document, options, cancellationToken);
+        var fileName = GetOutputFileName(document.FileName, ".docx");
+
+        return ConversionResult.SuccessBytes(bytes, DocumentFormat.Word, fileName);
+    }
+
+    private async Task<ConversionResult> ConvertToMarkdownAsync(Document document, ConversionOptions? options, CancellationToken cancellationToken)
+    {
+        var markdown = await _markdownService.ToMarkdownAsync(document, options, cancellationToken);
+        var fileName = GetOutputFileName(document.FileName, ".md");
+
+        return ConversionResult.SuccessText(markdown, DocumentFormat.Markdown, fileName);
+    }
+
+    private async Task<ConversionResult> ConvertToPdfAsync(Document document, ConversionOptions? options, CancellationToken cancellationToken)
+    {
+        var bytes = await _pdfService.ToPdfAsync(document, options, cancellationToken);
+        var fileName = GetOutputFileName(document.FileName, ".pdf");
+
+        return ConversionResult.SuccessBytes(bytes, DocumentFormat.Pdf, fileName);
+    }
+
+    private async Task<ConversionResult> ConvertToHtmlAsync(Document document, ConversionOptions? options, CancellationToken cancellationToken)
+    {
+        var html = await _markdownService.ToHtmlAsync(document, options, cancellationToken);
+        var fileName = GetOutputFileName(document.FileName, ".html");
+
+        return ConversionResult.SuccessText(html, DocumentFormat.Html, fileName);
+    }
+
+    private ConversionResult ConvertToPlainText(Document document)
+    {
+        var text = document.GetPlainText();
+        var fileName = GetOutputFileName(document.FileName, ".txt");
+
+        return ConversionResult.SuccessText(text, DocumentFormat.PlainText, fileName);
+    }
+
+    private string GetOutputFileName(string? sourceFileName, string newExtension)
+    {
+        if (string.IsNullOrEmpty(sourceFileName))
+        {
+            return $"document{newExtension}";
+        }
+
+        return Path.ChangeExtension(sourceFileName, newExtension);
+    }
+}

--- a/Mostlylucid.DocumentConversion/Services/MarkdownConversionService.cs
+++ b/Mostlylucid.DocumentConversion/Services/MarkdownConversionService.cs
@@ -1,0 +1,610 @@
+using System.Text;
+using Markdig;
+using Markdig.Extensions.Tables;
+using Markdig.Renderers.Normalize;
+using Markdig.Syntax;
+using Markdig.Syntax.Inlines;
+using Microsoft.Extensions.Logging;
+using Mostlylucid.DocumentConversion.Interfaces;
+using Mostlylucid.DocumentConversion.Models;
+
+namespace Mostlylucid.DocumentConversion.Services;
+
+/// <summary>
+/// Service for converting to and from Markdown format using Markdig
+/// </summary>
+public class MarkdownConversionService : IMarkdownConversionService
+{
+    private readonly ILogger<MarkdownConversionService> _logger;
+    private readonly MarkdownPipeline _pipeline;
+    private readonly MarkdownPipeline _plainTextPipeline;
+
+    public MarkdownConversionService(ILogger<MarkdownConversionService> logger)
+    {
+        _logger = logger;
+        _pipeline = new MarkdownPipelineBuilder()
+            .UseAdvancedExtensions()
+            .UsePipeTables()
+            .UseAutoLinks()
+            .UseEmphasisExtras()
+            .UseTaskLists()
+            .Build();
+
+        _plainTextPipeline = new MarkdownPipelineBuilder()
+            .Build();
+    }
+
+    public async Task<Document> ReadAsync(string filePath, CancellationToken cancellationToken = default)
+    {
+        var content = await File.ReadAllTextAsync(filePath, cancellationToken);
+        return await ParseAsync(content, Path.GetFileName(filePath), cancellationToken);
+    }
+
+    public Task<Document> ParseAsync(string markdown, string? fileName = null, CancellationToken cancellationToken = default)
+    {
+        return Task.Run(() =>
+        {
+            var document = new Document
+            {
+                FileName = fileName,
+                SourceFormat = DocumentFormat.Markdown
+            };
+
+            var markdownDoc = Markdown.Parse(markdown, _pipeline);
+
+            int order = 0;
+            foreach (var block in markdownDoc)
+            {
+                var element = ConvertBlock(block, ref order);
+                if (element != null)
+                {
+                    document.Elements.Add(element);
+                }
+            }
+
+            // Extract title from first heading
+            var firstHeading = document.Elements.OfType<HeadingElement>().FirstOrDefault();
+            if (firstHeading != null)
+            {
+                document.Title = firstHeading.Text;
+            }
+
+            return document;
+        }, cancellationToken);
+    }
+
+    public Task<string> ToMarkdownAsync(Document document, ConversionOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        return Task.Run(() =>
+        {
+            var sb = new StringBuilder();
+            var useGfm = options?.UseGitHubFlavoredMarkdown ?? true;
+
+            foreach (var element in document.Elements)
+            {
+                var markdown = ConvertElementToMarkdown(element, options, useGfm);
+                if (!string.IsNullOrEmpty(markdown))
+                {
+                    sb.AppendLine(markdown);
+                    sb.AppendLine();
+                }
+            }
+
+            return sb.ToString().TrimEnd();
+        }, cancellationToken);
+    }
+
+    public Task<string> ToHtmlAsync(string markdown, CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(Markdown.ToHtml(markdown, _pipeline));
+    }
+
+    public async Task<string> ToHtmlAsync(Document document, ConversionOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        var markdown = await ToMarkdownAsync(document, options, cancellationToken);
+        var html = Markdown.ToHtml(markdown, _pipeline);
+
+        // Wrap in HTML document if requested
+        if (options?.CustomCss != null)
+        {
+            html = WrapInHtmlDocument(html, document.Title, options.CustomCss);
+        }
+
+        return html;
+    }
+
+    public Task<string> ToPlainTextAsync(string markdown, CancellationToken cancellationToken = default)
+    {
+        return Task.Run(() =>
+        {
+            var doc = Markdown.Parse(markdown, _plainTextPipeline);
+            return ExtractPlainText(doc);
+        }, cancellationToken);
+    }
+
+    private DocumentElement? ConvertBlock(Block block, ref int order)
+    {
+        return block switch
+        {
+            HeadingBlock heading => ConvertHeading(heading, ref order),
+            ParagraphBlock paragraph => ConvertParagraph(paragraph, ref order),
+            FencedCodeBlock codeBlock => ConvertFencedCodeBlock(codeBlock, ref order),
+            CodeBlock codeBlock => ConvertCodeBlock(codeBlock, ref order),
+            QuoteBlock quote => ConvertQuoteBlock(quote, ref order),
+            ListBlock list => ConvertListBlock(list, ref order),
+            ThematicBreakBlock => new HorizontalRuleElement { Order = order++ },
+            Markdig.Extensions.Tables.Table table => ConvertTable(table, ref order),
+            _ => null
+        };
+    }
+
+    private HeadingElement ConvertHeading(HeadingBlock heading, ref int order)
+    {
+        var text = GetInlineText(heading.Inline);
+        var runs = GetInlineRuns(heading.Inline);
+
+        return new HeadingElement
+        {
+            Order = order++,
+            Level = heading.Level,
+            Text = text,
+            Runs = runs
+        };
+    }
+
+    private ParagraphElement ConvertParagraph(ParagraphBlock paragraph, ref int order)
+    {
+        var text = GetInlineText(paragraph.Inline);
+        var runs = GetInlineRuns(paragraph.Inline);
+
+        return new ParagraphElement
+        {
+            Order = order++,
+            Text = text,
+            Runs = runs
+        };
+    }
+
+    private CodeBlockElement ConvertFencedCodeBlock(FencedCodeBlock codeBlock, ref int order)
+    {
+        var code = string.Join("\n", codeBlock.Lines.Lines.Select(l => l.Slice.ToString()));
+
+        return new CodeBlockElement
+        {
+            Order = order++,
+            Code = code.TrimEnd(),
+            Language = codeBlock.Info
+        };
+    }
+
+    private CodeBlockElement ConvertCodeBlock(CodeBlock codeBlock, ref int order)
+    {
+        var code = string.Join("\n", codeBlock.Lines.Lines.Select(l => l.Slice.ToString()));
+
+        return new CodeBlockElement
+        {
+            Order = order++,
+            Code = code.TrimEnd()
+        };
+    }
+
+    private BlockQuoteElement ConvertQuoteBlock(QuoteBlock quote, ref int order)
+    {
+        var content = new List<DocumentElement>();
+        int childOrder = 0;
+
+        foreach (var block in quote)
+        {
+            var element = ConvertBlock(block, ref childOrder);
+            if (element != null)
+            {
+                content.Add(element);
+            }
+        }
+
+        var text = string.Join("\n", content
+            .Select(e => e switch
+            {
+                ParagraphElement p => p.Text,
+                HeadingElement h => h.Text,
+                _ => ""
+            })
+            .Where(t => !string.IsNullOrEmpty(t)));
+
+        return new BlockQuoteElement
+        {
+            Order = order++,
+            Content = content,
+            Text = text
+        };
+    }
+
+    private ListElement ConvertListBlock(ListBlock list, ref int order)
+    {
+        var listElement = new ListElement
+        {
+            Order = order++,
+            ListType = list.IsOrdered ? ListType.Numbered : ListType.Bullet,
+            StartNumber = list.OrderedStart != null ? int.Parse(list.OrderedStart) : 1
+        };
+
+        int itemOrder = 0;
+        foreach (var item in list.OfType<ListItemBlock>())
+        {
+            var itemText = new StringBuilder();
+            var runs = new List<TextRun>();
+
+            foreach (var block in item)
+            {
+                if (block is ParagraphBlock paragraph)
+                {
+                    itemText.Append(GetInlineText(paragraph.Inline));
+                    runs.AddRange(GetInlineRuns(paragraph.Inline));
+                }
+            }
+
+            // Check for nested lists
+            ListElement? nestedList = null;
+            foreach (var block in item)
+            {
+                if (block is ListBlock nested)
+                {
+                    int nestedOrder = 0;
+                    nestedList = ConvertListBlock(nested, ref nestedOrder);
+                }
+            }
+
+            listElement.Items.Add(new ListItemElement
+            {
+                Order = itemOrder++,
+                Text = itemText.ToString(),
+                Runs = runs,
+                NestedList = nestedList
+            });
+        }
+
+        return listElement;
+    }
+
+    private TableElement ConvertTable(Markdig.Extensions.Tables.Table table, ref int order)
+    {
+        var tableElement = new TableElement
+        {
+            Order = order++
+        };
+
+        bool isFirstRow = true;
+        foreach (var row in table.OfType<TableRow>())
+        {
+            var tableRow = new Models.TableRow
+            {
+                IsHeader = row.IsHeader || isFirstRow
+            };
+
+            foreach (var cell in row.OfType<TableCell>())
+            {
+                var cellText = new StringBuilder();
+                foreach (var block in cell)
+                {
+                    if (block is ParagraphBlock paragraph)
+                    {
+                        cellText.Append(GetInlineText(paragraph.Inline));
+                    }
+                }
+
+                tableRow.Cells.Add(new Models.TableCell
+                {
+                    Text = cellText.ToString(),
+                    ColumnSpan = cell.ColumnSpan,
+                    RowSpan = cell.RowSpan
+                });
+            }
+
+            tableElement.Rows.Add(tableRow);
+            if (isFirstRow && tableRow.IsHeader)
+            {
+                tableElement.HasHeaderRow = true;
+            }
+            isFirstRow = false;
+        }
+
+        return tableElement;
+    }
+
+    private string GetInlineText(ContainerInline? inline)
+    {
+        if (inline == null) return string.Empty;
+
+        var sb = new StringBuilder();
+        foreach (var child in inline)
+        {
+            sb.Append(GetInlineItemText(child));
+        }
+        return sb.ToString();
+    }
+
+    private string GetInlineItemText(Inline inline)
+    {
+        return inline switch
+        {
+            LiteralInline literal => literal.Content.ToString(),
+            EmphasisInline emphasis => GetContainerInlineText(emphasis),
+            CodeInline code => code.Content,
+            LinkInline link => GetContainerInlineText(link),
+            AutolinkInline autolink => autolink.Url,
+            LineBreakInline => "\n",
+            HtmlInline html => html.Tag,
+            _ => string.Empty
+        };
+    }
+
+    private string GetContainerInlineText(ContainerInline container)
+    {
+        var sb = new StringBuilder();
+        foreach (var child in container)
+        {
+            sb.Append(GetInlineItemText(child));
+        }
+        return sb.ToString();
+    }
+
+    private List<TextRun> GetInlineRuns(ContainerInline? inline)
+    {
+        var runs = new List<TextRun>();
+        if (inline == null) return runs;
+
+        foreach (var child in inline)
+        {
+            runs.AddRange(GetInlineItemRuns(child, false, false, false));
+        }
+
+        return runs;
+    }
+
+    private List<TextRun> GetInlineItemRuns(Inline inline, bool isBold, bool isItalic, bool isCode)
+    {
+        var runs = new List<TextRun>();
+
+        switch (inline)
+        {
+            case LiteralInline literal:
+                runs.Add(new TextRun
+                {
+                    Text = literal.Content.ToString(),
+                    IsBold = isBold,
+                    IsItalic = isItalic,
+                    IsCode = isCode
+                });
+                break;
+
+            case EmphasisInline emphasis:
+                var emphasisBold = isBold || (emphasis.DelimiterCount == 2 && emphasis.DelimiterChar is '*' or '_');
+                var emphasisItalic = isItalic || (emphasis.DelimiterCount == 1 && emphasis.DelimiterChar is '*' or '_');
+                foreach (var child in emphasis)
+                {
+                    runs.AddRange(GetInlineItemRuns(child, emphasisBold, emphasisItalic, isCode));
+                }
+                break;
+
+            case CodeInline code:
+                runs.Add(new TextRun
+                {
+                    Text = code.Content,
+                    IsCode = true
+                });
+                break;
+
+            case LinkInline link:
+                var linkText = GetContainerInlineText(link);
+                runs.Add(new TextRun
+                {
+                    Text = linkText,
+                    HyperlinkUrl = link.Url,
+                    IsUnderline = true
+                });
+                break;
+
+            case AutolinkInline autolink:
+                runs.Add(new TextRun
+                {
+                    Text = autolink.Url,
+                    HyperlinkUrl = autolink.Url,
+                    IsUnderline = true
+                });
+                break;
+        }
+
+        return runs;
+    }
+
+    private string ConvertElementToMarkdown(DocumentElement element, ConversionOptions? options, bool useGfm)
+    {
+        return element switch
+        {
+            HeadingElement h => $"{new string('#', h.Level)} {FormatRuns(h.Runs, h.Text)}",
+            ParagraphElement p => FormatRuns(p.Runs, p.Text),
+            CodeBlockElement c => FormatCodeBlock(c, useGfm),
+            BlockQuoteElement b => FormatBlockQuote(b),
+            ListElement l => FormatList(l, options),
+            TableElement t => FormatTable(t, useGfm),
+            ImageElement i => FormatImage(i, options),
+            HorizontalRuleElement => "---",
+            HyperlinkElement h => $"[{h.Text}]({h.Url})",
+            _ => string.Empty
+        };
+    }
+
+    private string FormatRuns(List<TextRun> runs, string fallbackText)
+    {
+        if (runs.Count == 0) return fallbackText;
+
+        var sb = new StringBuilder();
+        foreach (var run in runs)
+        {
+            var text = run.Text;
+
+            if (run.IsCode)
+            {
+                text = $"`{text}`";
+            }
+            else
+            {
+                if (run.IsBold && run.IsItalic)
+                {
+                    text = $"***{text}***";
+                }
+                else if (run.IsBold)
+                {
+                    text = $"**{text}**";
+                }
+                else if (run.IsItalic)
+                {
+                    text = $"*{text}*";
+                }
+
+                if (run.IsStrikethrough)
+                {
+                    text = $"~~{text}~~";
+                }
+            }
+
+            if (!string.IsNullOrEmpty(run.HyperlinkUrl))
+            {
+                text = $"[{text}]({run.HyperlinkUrl})";
+            }
+
+            sb.Append(text);
+        }
+
+        return sb.ToString();
+    }
+
+    private string FormatCodeBlock(CodeBlockElement codeBlock, bool useGfm)
+    {
+        if (useGfm)
+        {
+            var lang = codeBlock.Language ?? string.Empty;
+            return $"```{lang}\n{codeBlock.Code}\n```";
+        }
+        else
+        {
+            // Indent code block
+            var lines = codeBlock.Code.Split('\n');
+            return string.Join("\n", lines.Select(l => $"    {l}"));
+        }
+    }
+
+    private string FormatBlockQuote(BlockQuoteElement blockQuote)
+    {
+        var lines = blockQuote.Text.Split('\n');
+        return string.Join("\n", lines.Select(l => $"> {l}"));
+    }
+
+    private string FormatList(ListElement list, ConversionOptions? options, int indentLevel = 0)
+    {
+        var sb = new StringBuilder();
+        var indent = new string(' ', indentLevel * 2);
+        int itemNumber = list.StartNumber;
+
+        foreach (var item in list.Items)
+        {
+            var prefix = list.ListType == ListType.Bullet ? "-" : $"{itemNumber++}.";
+            sb.AppendLine($"{indent}{prefix} {FormatRuns(item.Runs, item.Text)}");
+
+            if (item.NestedList != null)
+            {
+                sb.Append(FormatList(item.NestedList, options, indentLevel + 1));
+            }
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+
+    private string FormatTable(TableElement table, bool useGfm)
+    {
+        if (!useGfm || table.Rows.Count == 0) return string.Empty;
+
+        var sb = new StringBuilder();
+        var firstRow = table.Rows.First();
+        var columnCount = firstRow.Cells.Count;
+
+        // Header row
+        sb.AppendLine($"| {string.Join(" | ", firstRow.Cells.Select(c => c.Text))} |");
+
+        // Separator row
+        sb.AppendLine($"| {string.Join(" | ", Enumerable.Repeat("---", columnCount))} |");
+
+        // Data rows
+        foreach (var row in table.Rows.Skip(table.HasHeaderRow ? 1 : 0))
+        {
+            var cells = row.Cells.Select(c => c.Text).ToList();
+            // Pad if necessary
+            while (cells.Count < columnCount) cells.Add(string.Empty);
+            sb.AppendLine($"| {string.Join(" | ", cells)} |");
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+
+    private string FormatImage(ImageElement image, ConversionOptions? options)
+    {
+        var alt = image.AltText ?? "image";
+
+        if (options?.EmbedImagesAsDataUri == true && image.DataUri != null)
+        {
+            return $"![{alt}]({image.DataUri})";
+        }
+        else if (!string.IsNullOrEmpty(image.FileName))
+        {
+            return $"![{alt}]({image.FileName})";
+        }
+
+        return string.Empty;
+    }
+
+    private string ExtractPlainText(MarkdownDocument document)
+    {
+        var sb = new StringBuilder();
+
+        foreach (var block in document)
+        {
+            ExtractBlockText(block, sb);
+            sb.AppendLine();
+        }
+
+        return sb.ToString().Trim();
+    }
+
+    private void ExtractBlockText(Block block, StringBuilder sb)
+    {
+        switch (block)
+        {
+            case LeafBlock leaf when leaf.Inline != null:
+                sb.Append(GetInlineText(leaf.Inline));
+                break;
+            case ContainerBlock container:
+                foreach (var child in container)
+                {
+                    ExtractBlockText(child, sb);
+                }
+                break;
+        }
+    }
+
+    private string WrapInHtmlDocument(string bodyHtml, string? title, string css)
+    {
+        return $@"<!DOCTYPE html>
+<html>
+<head>
+    <meta charset=""utf-8"">
+    <title>{title ?? "Document"}</title>
+    <style>
+{css}
+    </style>
+</head>
+<body>
+{bodyHtml}
+</body>
+</html>";
+    }
+}

--- a/Mostlylucid.DocumentConversion/Services/PdfConversionService.cs
+++ b/Mostlylucid.DocumentConversion/Services/PdfConversionService.cs
@@ -1,0 +1,462 @@
+using Microsoft.Extensions.Logging;
+using Mostlylucid.DocumentConversion.Interfaces;
+using Mostlylucid.DocumentConversion.Models;
+using QuestPDF.Fluent;
+using QuestPDF.Helpers;
+using QuestPDF.Infrastructure;
+
+namespace Mostlylucid.DocumentConversion.Services;
+
+/// <summary>
+/// Service for generating PDF documents using QuestPDF
+/// </summary>
+public class PdfConversionService : IPdfConversionService
+{
+    private readonly ILogger<PdfConversionService> _logger;
+    private readonly IMarkdownConversionService _markdownService;
+
+    // Font configuration
+    private const string DefaultFont = "Arial";
+    private const string MonospaceFont = "Courier New";
+    private const float BaseFontSize = 11f;
+    private const float LineHeight = 1.4f;
+
+    public PdfConversionService(
+        ILogger<PdfConversionService> logger,
+        IMarkdownConversionService markdownService)
+    {
+        _logger = logger;
+        _markdownService = markdownService;
+
+        // Configure QuestPDF license (Community license is free)
+        QuestPDF.Settings.License = LicenseType.Community;
+    }
+
+    public async Task<byte[]> ToPdfAsync(Document document, ConversionOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        return await Task.Run(() =>
+        {
+            var pdfDocument = QuestPDF.Fluent.Document.Create(container =>
+            {
+                container.Page(page =>
+                {
+                    ConfigurePage(page, options);
+
+                    page.Header().Element(header => RenderHeader(header, document));
+                    page.Content().Element(content => RenderContent(content, document, options));
+                    page.Footer().Element(footer => RenderFooter(footer));
+                });
+            });
+
+            return pdfDocument.GeneratePdf();
+        }, cancellationToken);
+    }
+
+    public async Task ToPdfFileAsync(Document document, string filePath, ConversionOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        var bytes = await ToPdfAsync(document, options, cancellationToken);
+        await File.WriteAllBytesAsync(filePath, bytes, cancellationToken);
+    }
+
+    public async Task<byte[]> MarkdownToPdfAsync(string markdown, ConversionOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        var document = await _markdownService.ParseAsync(markdown, null, cancellationToken);
+        return await ToPdfAsync(document, options, cancellationToken);
+    }
+
+    public async Task<byte[]> HtmlToPdfAsync(string html, ConversionOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        // For HTML, we'll create a simple document with the HTML as text
+        // Note: Full HTML rendering would require a more complex solution
+        _logger.LogWarning("HTML to PDF conversion provides basic text extraction only. For full HTML rendering, consider using a browser-based solution.");
+
+        var document = new Document
+        {
+            SourceFormat = DocumentFormat.Html,
+            Elements =
+            [
+                new ParagraphElement
+                {
+                    Text = StripHtmlTags(html),
+                    Order = 0
+                }
+            ]
+        };
+
+        return await ToPdfAsync(document, options, cancellationToken);
+    }
+
+    private void ConfigurePage(PageDescriptor page, ConversionOptions? options)
+    {
+        var pageSize = options?.PageSize ?? PdfPageSize.A4;
+        var orientation = options?.Orientation ?? PdfOrientation.Portrait;
+
+        var size = pageSize switch
+        {
+            PdfPageSize.A3 => PageSizes.A3,
+            PdfPageSize.A5 => PageSizes.A5,
+            PdfPageSize.Letter => PageSizes.Letter,
+            PdfPageSize.Legal => PageSizes.Legal,
+            _ => PageSizes.A4
+        };
+
+        if (orientation == PdfOrientation.Landscape)
+        {
+            size = size.Landscape();
+        }
+
+        page.Size(size);
+        page.Margin(50);
+        page.DefaultTextStyle(style => style
+            .FontFamily(DefaultFont)
+            .FontSize(BaseFontSize)
+            .LineHeight(LineHeight));
+    }
+
+    private void RenderHeader(IContainer container, Document document)
+    {
+        if (string.IsNullOrEmpty(document.Title)) return;
+
+        container
+            .PaddingBottom(10)
+            .BorderBottom(1)
+            .BorderColor(Colors.Grey.Lighten1)
+            .Text(document.Title)
+            .FontSize(10)
+            .FontColor(Colors.Grey.Medium);
+    }
+
+    private void RenderFooter(IContainer container)
+    {
+        container
+            .AlignCenter()
+            .Text(text =>
+            {
+                text.CurrentPageNumber();
+                text.Span(" / ");
+                text.TotalPages();
+            });
+    }
+
+    private void RenderContent(IContainer container, Document document, ConversionOptions? options)
+    {
+        container.Column(column =>
+        {
+            column.Spacing(10);
+
+            foreach (var element in document.Elements)
+            {
+                column.Item().Element(item => RenderElement(item, element, options));
+            }
+        });
+    }
+
+    private void RenderElement(IContainer container, DocumentElement element, ConversionOptions? options)
+    {
+        switch (element)
+        {
+            case HeadingElement heading:
+                RenderHeading(container, heading);
+                break;
+            case ParagraphElement paragraph:
+                RenderParagraph(container, paragraph, options);
+                break;
+            case CodeBlockElement codeBlock:
+                RenderCodeBlock(container, codeBlock);
+                break;
+            case BlockQuoteElement blockQuote:
+                RenderBlockQuote(container, blockQuote);
+                break;
+            case ListElement list:
+                RenderList(container, list);
+                break;
+            case TableElement table when options?.IncludeTables != false:
+                RenderTable(container, table);
+                break;
+            case ImageElement image when options?.IncludeImages != false:
+                RenderImage(container, image);
+                break;
+            case HorizontalRuleElement:
+                RenderHorizontalRule(container);
+                break;
+        }
+    }
+
+    private void RenderHeading(IContainer container, HeadingElement heading)
+    {
+        var fontSize = heading.Level switch
+        {
+            1 => 24f,
+            2 => 20f,
+            3 => 16f,
+            4 => 14f,
+            5 => 12f,
+            _ => 11f
+        };
+
+        container.Text(text =>
+        {
+            if (heading.Runs.Count > 0)
+            {
+                RenderTextRuns(text, heading.Runs, fontSize, true);
+            }
+            else
+            {
+                text.Span(heading.Text)
+                    .FontSize(fontSize)
+                    .Bold();
+            }
+        });
+    }
+
+    private void RenderParagraph(IContainer container, ParagraphElement paragraph, ConversionOptions? options)
+    {
+        container.Text(text =>
+        {
+            if (paragraph.Runs.Count > 0 && options?.PreserveFormatting != false)
+            {
+                RenderTextRuns(text, paragraph.Runs, BaseFontSize, false);
+            }
+            else
+            {
+                text.Span(paragraph.Text);
+            }
+        });
+    }
+
+    private void RenderTextRuns(TextDescriptor text, List<TextRun> runs, float baseFontSize, bool isHeading)
+    {
+        foreach (var run in runs)
+        {
+            var span = text.Span(run.Text);
+
+            span.FontSize(run.FontSize.HasValue ? (float)run.FontSize.Value : baseFontSize);
+
+            if (run.IsBold || isHeading) span.Bold();
+            if (run.IsItalic) span.Italic();
+            if (run.IsUnderline) span.Underline();
+            if (run.IsStrikethrough) span.Strikethrough();
+
+            if (run.IsCode)
+            {
+                span.FontFamily(MonospaceFont)
+                    .BackgroundColor(Colors.Grey.Lighten3);
+            }
+
+            if (!string.IsNullOrEmpty(run.Color) && TryParseColor(run.Color, out var color))
+            {
+                span.FontColor(color);
+            }
+
+            if (!string.IsNullOrEmpty(run.HyperlinkUrl))
+            {
+                span.FontColor(Colors.Blue.Medium)
+                    .Underline();
+            }
+
+            if (!string.IsNullOrEmpty(run.FontName))
+            {
+                span.FontFamily(run.FontName);
+            }
+        }
+    }
+
+    private void RenderCodeBlock(IContainer container, CodeBlockElement codeBlock)
+    {
+        container
+            .Background(Colors.Grey.Lighten4)
+            .Border(1)
+            .BorderColor(Colors.Grey.Lighten2)
+            .Padding(10)
+            .Text(text =>
+            {
+                text.Span(codeBlock.Code)
+                    .FontFamily(MonospaceFont)
+                    .FontSize(10);
+            });
+    }
+
+    private void RenderBlockQuote(IContainer container, BlockQuoteElement blockQuote)
+    {
+        container
+            .BorderLeft(3)
+            .BorderColor(Colors.Grey.Lighten1)
+            .PaddingLeft(15)
+            .Text(text =>
+            {
+                text.Span(blockQuote.Text)
+                    .Italic()
+                    .FontColor(Colors.Grey.Darken1);
+            });
+    }
+
+    private void RenderList(IContainer container, ListElement list, int indentLevel = 0)
+    {
+        container.Column(column =>
+        {
+            column.Spacing(5);
+
+            int itemNumber = list.StartNumber;
+            foreach (var item in list.Items)
+            {
+                column.Item().Row(row =>
+                {
+                    // Indent
+                    if (indentLevel > 0)
+                    {
+                        row.ConstantItem(indentLevel * 20);
+                    }
+
+                    // Bullet or number
+                    var prefix = list.ListType switch
+                    {
+                        ListType.Bullet => "•",
+                        ListType.Numbered => $"{itemNumber++}.",
+                        ListType.LetterLower => $"{(char)('a' + itemNumber++ - 1)}.",
+                        ListType.LetterUpper => $"{(char)('A' + itemNumber++ - 1)}.",
+                        _ => "•"
+                    };
+
+                    row.ConstantItem(25).Text(prefix);
+                    row.RelativeItem().Text(text =>
+                    {
+                        if (item.Runs.Count > 0)
+                        {
+                            RenderTextRuns(text, item.Runs, BaseFontSize, false);
+                        }
+                        else
+                        {
+                            text.Span(item.Text);
+                        }
+                    });
+                });
+
+                // Nested list
+                if (item.NestedList != null)
+                {
+                    column.Item().Element(nested =>
+                        RenderList(nested, item.NestedList, indentLevel + 1));
+                }
+            }
+        });
+    }
+
+    private void RenderTable(IContainer container, TableElement tableElement)
+    {
+        if (tableElement.Rows.Count == 0) return;
+
+        var columnCount = tableElement.Rows.Max(r => r.Cells.Count);
+        if (columnCount == 0) return;
+
+        container.Table(table =>
+        {
+            table.ColumnsDefinition(columns =>
+            {
+                for (int i = 0; i < columnCount; i++)
+                {
+                    columns.RelativeColumn();
+                }
+            });
+
+            foreach (var row in tableElement.Rows)
+            {
+                foreach (var cell in row.Cells)
+                {
+                    var cellElement = table.Cell()
+                        .Border(1)
+                        .BorderColor(Colors.Grey.Lighten1)
+                        .Padding(5);
+
+                    if (row.IsHeader)
+                    {
+                        cellElement
+                            .Background(Colors.Grey.Lighten3)
+                            .Text(cell.Text)
+                            .Bold();
+                    }
+                    else
+                    {
+                        cellElement.Text(cell.Text);
+                    }
+                }
+
+                // Pad with empty cells if necessary
+                for (int i = row.Cells.Count; i < columnCount; i++)
+                {
+                    table.Cell()
+                        .Border(1)
+                        .BorderColor(Colors.Grey.Lighten1)
+                        .Padding(5)
+                        .Text(string.Empty);
+                }
+            }
+        });
+    }
+
+    private void RenderImage(IContainer container, ImageElement image)
+    {
+        if (image.Data == null || image.Data.Length == 0) return;
+
+        try
+        {
+            container
+                .AlignCenter()
+                .MaxWidth(400)
+                .Image(image.Data);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to render image in PDF: {FileName}", image.FileName);
+            container.Text($"[Image: {image.FileName ?? "unnamed"}]")
+                .Italic()
+                .FontColor(Colors.Grey.Medium);
+        }
+    }
+
+    private void RenderHorizontalRule(IContainer container)
+    {
+        container
+            .PaddingVertical(10)
+            .LineHorizontal(1)
+            .LineColor(Colors.Grey.Lighten1);
+    }
+
+    private bool TryParseColor(string colorString, out string color)
+    {
+        color = Colors.Black;
+
+        if (string.IsNullOrEmpty(colorString)) return false;
+
+        // Handle hex colors
+        if (colorString.StartsWith('#'))
+        {
+            color = colorString;
+            return true;
+        }
+
+        // Handle named colors (basic mapping)
+        color = colorString.ToLowerInvariant() switch
+        {
+            "red" => Colors.Red.Medium,
+            "blue" => Colors.Blue.Medium,
+            "green" => Colors.Green.Medium,
+            "yellow" => Colors.Yellow.Medium,
+            "orange" => Colors.Orange.Medium,
+            "purple" => Colors.Purple.Medium,
+            "black" => Colors.Black,
+            "white" => Colors.White,
+            "grey" or "gray" => Colors.Grey.Medium,
+            _ => Colors.Black
+        };
+
+        return true;
+    }
+
+    private string StripHtmlTags(string html)
+    {
+        // Basic HTML tag stripping
+        var result = System.Text.RegularExpressions.Regex.Replace(html, "<[^>]*>", " ");
+        result = System.Text.RegularExpressions.Regex.Replace(result, @"\s+", " ");
+        return System.Net.WebUtility.HtmlDecode(result).Trim();
+    }
+}

--- a/Mostlylucid.DocumentConversion/Services/WordDocumentService.cs
+++ b/Mostlylucid.DocumentConversion/Services/WordDocumentService.cs
@@ -1,0 +1,736 @@
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using Microsoft.Extensions.Logging;
+using Mostlylucid.DocumentConversion.Interfaces;
+using Mostlylucid.DocumentConversion.Models;
+using A = DocumentFormat.OpenXml.Drawing;
+using DW = DocumentFormat.OpenXml.Drawing.Wordprocessing;
+using PIC = DocumentFormat.OpenXml.Drawing.Pictures;
+
+namespace Mostlylucid.DocumentConversion.Services;
+
+/// <summary>
+/// Service for reading and writing Word documents using Open XML SDK
+/// </summary>
+public class WordDocumentService : IWordDocumentService
+{
+    private readonly ILogger<WordDocumentService> _logger;
+
+    public WordDocumentService(ILogger<WordDocumentService> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task<Document> ReadAsync(string filePath, CancellationToken cancellationToken = default)
+    {
+        await using var stream = File.OpenRead(filePath);
+        return await ReadAsync(stream, Path.GetFileName(filePath), cancellationToken);
+    }
+
+    public async Task<Document> ReadAsync(byte[] data, string? fileName = null, CancellationToken cancellationToken = default)
+    {
+        using var stream = new MemoryStream(data);
+        return await ReadAsync(stream, fileName, cancellationToken);
+    }
+
+    public Task<Document> ReadAsync(Stream stream, string? fileName = null, CancellationToken cancellationToken = default)
+    {
+        return Task.Run(() =>
+        {
+            var document = new Document
+            {
+                FileName = fileName,
+                SourceFormat = DocumentFormat.Word
+            };
+
+            using var wordDoc = WordprocessingDocument.Open(stream, false);
+            var mainPart = wordDoc.MainDocumentPart;
+            if (mainPart == null)
+            {
+                _logger.LogWarning("Word document has no main document part");
+                return document;
+            }
+
+            // Extract metadata
+            ExtractMetadata(wordDoc, document);
+
+            // Extract body elements
+            var body = mainPart.Document?.Body;
+            if (body != null)
+            {
+                int order = 0;
+                foreach (var element in body.Elements())
+                {
+                    var extracted = ExtractElement(element, mainPart, ref order);
+                    if (extracted != null)
+                    {
+                        document.Elements.Add(extracted);
+                    }
+                }
+            }
+
+            // Extract images
+            document.Images.AddRange(ExtractAllImages(mainPart));
+
+            return document;
+        }, cancellationToken);
+    }
+
+    public async Task<byte[]> CreateAsync(Document document, ConversionOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        return await Task.Run(() =>
+        {
+            using var stream = new MemoryStream();
+            using (var wordDoc = WordprocessingDocument.Create(stream, WordprocessingDocumentType.Document))
+            {
+                var mainPart = wordDoc.AddMainDocumentPart();
+                mainPart.Document = new DocumentFormat.OpenXml.Wordprocessing.Document();
+                var body = mainPart.Document.AppendChild(new Body());
+
+                // Add metadata
+                AddMetadata(wordDoc, document);
+
+                // Add styles
+                AddStyles(mainPart);
+
+                // Convert elements to Word
+                foreach (var element in document.Elements)
+                {
+                    AddElement(body, mainPart, element, options);
+                }
+
+                mainPart.Document.Save();
+            }
+
+            return stream.ToArray();
+        }, cancellationToken);
+    }
+
+    public async Task WriteAsync(Document document, string filePath, ConversionOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        var bytes = await CreateAsync(document, options, cancellationToken);
+        await File.WriteAllBytesAsync(filePath, bytes, cancellationToken);
+    }
+
+    public Task<string> ExtractTextAsync(Stream stream, CancellationToken cancellationToken = default)
+    {
+        return Task.Run(() =>
+        {
+            using var wordDoc = WordprocessingDocument.Open(stream, false);
+            var body = wordDoc.MainDocumentPart?.Document?.Body;
+            if (body == null) return string.Empty;
+
+            return string.Join("\n", body.Descendants<Text>().Select(t => t.Text));
+        }, cancellationToken);
+    }
+
+    public Task<List<ImageElement>> ExtractImagesAsync(Stream stream, CancellationToken cancellationToken = default)
+    {
+        return Task.Run(() =>
+        {
+            using var wordDoc = WordprocessingDocument.Open(stream, false);
+            var mainPart = wordDoc.MainDocumentPart;
+            if (mainPart == null) return [];
+
+            return ExtractAllImages(mainPart);
+        }, cancellationToken);
+    }
+
+    private void ExtractMetadata(WordprocessingDocument wordDoc, Document document)
+    {
+        var coreProps = wordDoc.PackageProperties;
+        document.Title = coreProps.Title;
+        document.Author = coreProps.Creator;
+        document.Subject = coreProps.Subject;
+        document.CreatedDate = coreProps.Created;
+        document.ModifiedDate = coreProps.Modified;
+
+        if (!string.IsNullOrEmpty(coreProps.Keywords))
+        {
+            document.Keywords = coreProps.Keywords.Split(',', StringSplitOptions.RemoveEmptyEntries)
+                .Select(k => k.Trim()).ToList();
+        }
+    }
+
+    private DocumentElement? ExtractElement(OpenXmlElement element, MainDocumentPart mainPart, ref int order)
+    {
+        return element switch
+        {
+            Paragraph p => ExtractParagraph(p, mainPart, ref order),
+            Table t => ExtractTable(t, mainPart, ref order),
+            _ => null
+        };
+    }
+
+    private DocumentElement? ExtractParagraph(Paragraph paragraph, MainDocumentPart mainPart, ref int order)
+    {
+        var styleName = GetStyleName(paragraph, mainPart);
+        var headingLevel = GetHeadingLevel(styleName);
+
+        var runs = ExtractRuns(paragraph, mainPart);
+        var text = string.Join("", runs.Select(r => r.Text));
+
+        if (string.IsNullOrWhiteSpace(text) && !HasImage(paragraph))
+        {
+            return null;
+        }
+
+        // Check for images
+        var imageElement = ExtractImageFromParagraph(paragraph, mainPart, ref order);
+        if (imageElement != null)
+        {
+            return imageElement;
+        }
+
+        if (headingLevel > 0)
+        {
+            return new HeadingElement
+            {
+                Order = order++,
+                Level = headingLevel,
+                Text = text,
+                Runs = runs
+            };
+        }
+
+        return new ParagraphElement
+        {
+            Order = order++,
+            Text = text,
+            Runs = runs,
+            StyleName = styleName,
+            Alignment = GetAlignment(paragraph)
+        };
+    }
+
+    private List<TextRun> ExtractRuns(Paragraph paragraph, MainDocumentPart mainPart)
+    {
+        var textRuns = new List<TextRun>();
+
+        foreach (var run in paragraph.Elements<Run>())
+        {
+            var text = string.Join("", run.Elements<Text>().Select(t => t.Text));
+            if (string.IsNullOrEmpty(text)) continue;
+
+            var props = run.RunProperties;
+
+            textRuns.Add(new TextRun
+            {
+                Text = text,
+                IsBold = props?.Bold != null || props?.BoldComplexScript != null,
+                IsItalic = props?.Italic != null || props?.ItalicComplexScript != null,
+                IsUnderline = props?.Underline != null && props.Underline.Val?.Value != UnderlineValues.None,
+                IsStrikethrough = props?.Strike != null || props?.DoubleStrike != null,
+                FontName = props?.RunFonts?.Ascii?.Value,
+                FontSize = props?.FontSize?.Val != null ? double.Parse(props.FontSize.Val.Value) / 2 : null,
+                Color = props?.Color?.Val?.Value,
+                HighlightColor = props?.Highlight?.Val?.ToString()
+            });
+        }
+
+        // Check for hyperlinks
+        foreach (var hyperlink in paragraph.Elements<Hyperlink>())
+        {
+            var relationshipId = hyperlink.Id?.Value;
+            string? url = null;
+
+            if (relationshipId != null)
+            {
+                var relationship = mainPart.HyperlinkRelationships
+                    .FirstOrDefault(r => r.Id == relationshipId);
+                url = relationship?.Uri?.ToString();
+            }
+
+            foreach (var run in hyperlink.Elements<Run>())
+            {
+                var text = string.Join("", run.Elements<Text>().Select(t => t.Text));
+                if (string.IsNullOrEmpty(text)) continue;
+
+                textRuns.Add(new TextRun
+                {
+                    Text = text,
+                    HyperlinkUrl = url,
+                    IsUnderline = true,
+                    Color = "#0000FF" // Default link color
+                });
+            }
+        }
+
+        return textRuns;
+    }
+
+    private TableElement ExtractTable(Table table, MainDocumentPart mainPart, ref int order)
+    {
+        var tableElement = new TableElement
+        {
+            Order = order++
+        };
+
+        bool isFirstRow = true;
+        foreach (var row in table.Elements<TableRow>())
+        {
+            var tableRow = new TableRow
+            {
+                IsHeader = isFirstRow
+            };
+
+            foreach (var cell in row.Elements<TableCell>())
+            {
+                var cellText = string.Join(" ", cell.Descendants<Text>().Select(t => t.Text));
+                tableRow.Cells.Add(new TableCell
+                {
+                    Text = cellText
+                });
+            }
+
+            tableElement.Rows.Add(tableRow);
+            if (isFirstRow)
+            {
+                tableElement.HasHeaderRow = true;
+                isFirstRow = false;
+            }
+        }
+
+        return tableElement;
+    }
+
+    private ImageElement? ExtractImageFromParagraph(Paragraph paragraph, MainDocumentPart mainPart, ref int order)
+    {
+        var drawing = paragraph.Descendants<Drawing>().FirstOrDefault();
+        if (drawing == null) return null;
+
+        var blip = drawing.Descendants<A.Blip>().FirstOrDefault();
+        if (blip?.Embed?.Value == null) return null;
+
+        var imagePart = mainPart.GetPartById(blip.Embed.Value) as ImagePart;
+        if (imagePart == null) return null;
+
+        using var imageStream = imagePart.GetStream();
+        using var memoryStream = new MemoryStream();
+        imageStream.CopyTo(memoryStream);
+
+        var extent = drawing.Descendants<DW.Extent>().FirstOrDefault();
+
+        return new ImageElement
+        {
+            Order = order++,
+            Data = memoryStream.ToArray(),
+            ContentType = imagePart.ContentType,
+            Width = extent?.Cx != null ? (int)(extent.Cx.Value / 9525) : null, // EMUs to pixels
+            Height = extent?.Cy != null ? (int)(extent.Cy.Value / 9525) : null
+        };
+    }
+
+    private List<ImageElement> ExtractAllImages(MainDocumentPart mainPart)
+    {
+        var images = new List<ImageElement>();
+        int imageIndex = 0;
+
+        foreach (var imagePart in mainPart.ImageParts)
+        {
+            using var imageStream = imagePart.GetStream();
+            using var memoryStream = new MemoryStream();
+            imageStream.CopyTo(memoryStream);
+
+            var extension = GetImageExtension(imagePart.ContentType);
+            images.Add(new ImageElement
+            {
+                Data = memoryStream.ToArray(),
+                ContentType = imagePart.ContentType,
+                FileName = $"image{++imageIndex}{extension}"
+            });
+        }
+
+        return images;
+    }
+
+    private bool HasImage(Paragraph paragraph)
+    {
+        return paragraph.Descendants<Drawing>().Any();
+    }
+
+    private string? GetStyleName(Paragraph paragraph, MainDocumentPart mainPart)
+    {
+        var styleId = paragraph.ParagraphProperties?.ParagraphStyleId?.Val?.Value;
+        if (styleId == null) return null;
+
+        var styles = mainPart.StyleDefinitionsPart?.Styles;
+        var style = styles?.Elements<Style>().FirstOrDefault(s => s.StyleId?.Value == styleId);
+        return style?.StyleName?.Val?.Value ?? styleId;
+    }
+
+    private int GetHeadingLevel(string? styleName)
+    {
+        if (string.IsNullOrEmpty(styleName)) return 0;
+
+        // Check for "Heading 1", "Heading 2", etc.
+        if (styleName.StartsWith("Heading ", StringComparison.OrdinalIgnoreCase))
+        {
+            if (int.TryParse(styleName.AsSpan(8), out var level) && level is >= 1 and <= 6)
+            {
+                return level;
+            }
+        }
+
+        // Check for style IDs like "Heading1", "Heading2"
+        if (styleName.StartsWith("Heading", StringComparison.OrdinalIgnoreCase) && styleName.Length == 8)
+        {
+            if (int.TryParse(styleName.AsSpan(7), out var level) && level is >= 1 and <= 6)
+            {
+                return level;
+            }
+        }
+
+        return 0;
+    }
+
+    private TextAlignment GetAlignment(Paragraph paragraph)
+    {
+        var justification = paragraph.ParagraphProperties?.Justification?.Val?.Value;
+        return justification switch
+        {
+            JustificationValues.Center => TextAlignment.Center,
+            JustificationValues.Right => TextAlignment.Right,
+            JustificationValues.Both => TextAlignment.Justify,
+            _ => TextAlignment.Left
+        };
+    }
+
+    private string GetImageExtension(string contentType)
+    {
+        return contentType.ToLowerInvariant() switch
+        {
+            "image/png" => ".png",
+            "image/jpeg" => ".jpg",
+            "image/gif" => ".gif",
+            "image/bmp" => ".bmp",
+            "image/tiff" => ".tiff",
+            "image/svg+xml" => ".svg",
+            _ => ".bin"
+        };
+    }
+
+    private void AddMetadata(WordprocessingDocument wordDoc, Document document)
+    {
+        wordDoc.PackageProperties.Title = document.Title;
+        wordDoc.PackageProperties.Creator = document.Author;
+        wordDoc.PackageProperties.Subject = document.Subject;
+        wordDoc.PackageProperties.Created = document.CreatedDate ?? DateTime.Now;
+        wordDoc.PackageProperties.Modified = DateTime.Now;
+
+        if (document.Keywords.Count != 0)
+        {
+            wordDoc.PackageProperties.Keywords = string.Join(", ", document.Keywords);
+        }
+    }
+
+    private void AddStyles(MainDocumentPart mainPart)
+    {
+        var stylesPart = mainPart.AddNewPart<StyleDefinitionsPart>();
+        var styles = new Styles();
+
+        // Add heading styles
+        for (int i = 1; i <= 6; i++)
+        {
+            var style = new Style
+            {
+                Type = StyleValues.Paragraph,
+                StyleId = $"Heading{i}",
+                StyleName = new StyleName { Val = $"Heading {i}" }
+            };
+
+            var pPr = new StyleParagraphProperties();
+            var rPr = new StyleRunProperties
+            {
+                Bold = new Bold(),
+                FontSize = new FontSize { Val = ((32 - (i * 4)) * 2).ToString() }
+            };
+
+            style.Append(pPr);
+            style.Append(rPr);
+            styles.Append(style);
+        }
+
+        stylesPart.Styles = styles;
+    }
+
+    private void AddElement(Body body, MainDocumentPart mainPart, DocumentElement element, ConversionOptions? options)
+    {
+        switch (element)
+        {
+            case HeadingElement heading:
+                AddHeading(body, heading);
+                break;
+            case ParagraphElement paragraph:
+                AddParagraph(body, paragraph, options);
+                break;
+            case TableElement table:
+                AddTable(body, table);
+                break;
+            case ListElement list:
+                AddList(body, list);
+                break;
+            case ImageElement image when options?.IncludeImages != false:
+                AddImage(body, mainPart, image);
+                break;
+            case CodeBlockElement codeBlock:
+                AddCodeBlock(body, codeBlock);
+                break;
+            case BlockQuoteElement blockQuote:
+                AddBlockQuote(body, blockQuote);
+                break;
+            case HorizontalRuleElement:
+                AddHorizontalRule(body);
+                break;
+        }
+    }
+
+    private void AddHeading(Body body, HeadingElement heading)
+    {
+        var paragraph = new Paragraph();
+        var props = new ParagraphProperties
+        {
+            ParagraphStyleId = new ParagraphStyleId { Val = $"Heading{heading.Level}" }
+        };
+        paragraph.Append(props);
+
+        if (heading.Runs.Count != 0)
+        {
+            foreach (var textRun in heading.Runs)
+            {
+                paragraph.Append(CreateRun(textRun));
+            }
+        }
+        else
+        {
+            var run = new Run(new Text(heading.Text));
+            paragraph.Append(run);
+        }
+
+        body.Append(paragraph);
+    }
+
+    private void AddParagraph(Body body, ParagraphElement para, ConversionOptions? options)
+    {
+        var paragraph = new Paragraph();
+        var props = new ParagraphProperties();
+
+        if (para.Alignment != TextAlignment.Left)
+        {
+            props.Justification = new Justification
+            {
+                Val = para.Alignment switch
+                {
+                    TextAlignment.Center => JustificationValues.Center,
+                    TextAlignment.Right => JustificationValues.Right,
+                    TextAlignment.Justify => JustificationValues.Both,
+                    _ => JustificationValues.Left
+                }
+            };
+        }
+
+        paragraph.Append(props);
+
+        if (para.Runs.Count != 0 && options?.PreserveFormatting != false)
+        {
+            foreach (var textRun in para.Runs)
+            {
+                paragraph.Append(CreateRun(textRun));
+            }
+        }
+        else
+        {
+            var run = new Run(new Text(para.Text));
+            paragraph.Append(run);
+        }
+
+        body.Append(paragraph);
+    }
+
+    private Run CreateRun(TextRun textRun)
+    {
+        var run = new Run();
+        var props = new RunProperties();
+
+        if (textRun.IsBold) props.Bold = new Bold();
+        if (textRun.IsItalic) props.Italic = new Italic();
+        if (textRun.IsUnderline) props.Underline = new Underline { Val = UnderlineValues.Single };
+        if (textRun.IsStrikethrough) props.Strike = new Strike();
+        if (!string.IsNullOrEmpty(textRun.Color)) props.Color = new Color { Val = textRun.Color.TrimStart('#') };
+        if (!string.IsNullOrEmpty(textRun.FontName)) props.RunFonts = new RunFonts { Ascii = textRun.FontName };
+        if (textRun.FontSize.HasValue) props.FontSize = new FontSize { Val = ((int)(textRun.FontSize.Value * 2)).ToString() };
+
+        run.Append(props);
+        run.Append(new Text(textRun.Text) { Space = SpaceProcessingModeValues.Preserve });
+
+        return run;
+    }
+
+    private void AddTable(Body body, TableElement tableElement)
+    {
+        var table = new Table();
+
+        var tableProps = new TableProperties(
+            new TableBorders(
+                new TopBorder { Val = BorderValues.Single, Size = 4 },
+                new BottomBorder { Val = BorderValues.Single, Size = 4 },
+                new LeftBorder { Val = BorderValues.Single, Size = 4 },
+                new RightBorder { Val = BorderValues.Single, Size = 4 },
+                new InsideHorizontalBorder { Val = BorderValues.Single, Size = 4 },
+                new InsideVerticalBorder { Val = BorderValues.Single, Size = 4 }
+            )
+        );
+        table.Append(tableProps);
+
+        foreach (var rowElement in tableElement.Rows)
+        {
+            var row = new DocumentFormat.OpenXml.Wordprocessing.TableRow();
+
+            foreach (var cellElement in rowElement.Cells)
+            {
+                var cell = new DocumentFormat.OpenXml.Wordprocessing.TableCell();
+                var cellParagraph = new Paragraph(new Run(new Text(cellElement.Text)));
+
+                if (rowElement.IsHeader)
+                {
+                    var runProps = cellParagraph.Descendants<Run>().First().PrependChild(new RunProperties());
+                    runProps.Bold = new Bold();
+                }
+
+                cell.Append(cellParagraph);
+                row.Append(cell);
+            }
+
+            table.Append(row);
+        }
+
+        body.Append(table);
+        body.Append(new Paragraph()); // Add spacing after table
+    }
+
+    private void AddList(Body body, ListElement listElement)
+    {
+        foreach (var item in listElement.Items)
+        {
+            var paragraph = new Paragraph();
+            var prefix = listElement.ListType == ListType.Bullet ? "• " : $"{listElement.StartNumber + listElement.Items.IndexOf(item)}. ";
+            var run = new Run(new Text(prefix + item.Text));
+            paragraph.Append(run);
+            body.Append(paragraph);
+        }
+    }
+
+    private void AddImage(Body body, MainDocumentPart mainPart, ImageElement imageElement)
+    {
+        if (imageElement.Data == null) return;
+
+        var imagePart = mainPart.AddImagePart(GetImagePartType(imageElement.ContentType));
+        using var stream = new MemoryStream(imageElement.Data);
+        imagePart.FeedData(stream);
+
+        var relationshipId = mainPart.GetIdOfPart(imagePart);
+        var width = (imageElement.Width ?? 400) * 9525L; // Pixels to EMUs
+        var height = (imageElement.Height ?? 300) * 9525L;
+
+        var element = new Drawing(
+            new DW.Inline(
+                new DW.Extent { Cx = width, Cy = height },
+                new DW.EffectExtent { LeftEdge = 0L, TopEdge = 0L, RightEdge = 0L, BottomEdge = 0L },
+                new DW.DocProperties { Id = 1U, Name = imageElement.FileName ?? "Image" },
+                new DW.NonVisualGraphicFrameDrawingProperties(
+                    new A.GraphicFrameLocks { NoChangeAspect = true }),
+                new A.Graphic(
+                    new A.GraphicData(
+                        new PIC.Picture(
+                            new PIC.NonVisualPictureProperties(
+                                new PIC.NonVisualDrawingProperties { Id = 0U, Name = imageElement.FileName ?? "Image" },
+                                new PIC.NonVisualPictureDrawingProperties()),
+                            new PIC.BlipFill(
+                                new A.Blip { Embed = relationshipId },
+                                new A.Stretch(new A.FillRectangle())),
+                            new PIC.ShapeProperties(
+                                new A.Transform2D(
+                                    new A.Offset { X = 0L, Y = 0L },
+                                    new A.Extents { Cx = width, Cy = height }),
+                                new A.PresetGeometry(new A.AdjustValueList()) { Preset = A.ShapeTypeValues.Rectangle }))
+                    ) { Uri = "http://schemas.openxmlformats.org/drawingml/2006/picture" })
+            ) { DistanceFromTop = 0U, DistanceFromBottom = 0U, DistanceFromLeft = 0U, DistanceFromRight = 0U }
+        );
+
+        var paragraph = new Paragraph(new Run(element));
+        body.Append(paragraph);
+    }
+
+    private ImagePartType GetImagePartType(string? contentType)
+    {
+        return contentType?.ToLowerInvariant() switch
+        {
+            "image/png" => ImagePartType.Png,
+            "image/jpeg" or "image/jpg" => ImagePartType.Jpeg,
+            "image/gif" => ImagePartType.Gif,
+            "image/bmp" => ImagePartType.Bmp,
+            "image/tiff" => ImagePartType.Tiff,
+            _ => ImagePartType.Png
+        };
+    }
+
+    private void AddCodeBlock(Body body, CodeBlockElement codeBlock)
+    {
+        // Add code block as a paragraph with monospace font
+        var paragraph = new Paragraph();
+        var props = new ParagraphProperties
+        {
+            Shading = new Shading { Val = ShadingPatternValues.Clear, Fill = "F5F5F5" }
+        };
+        paragraph.Append(props);
+
+        var run = new Run();
+        var runProps = new RunProperties
+        {
+            RunFonts = new RunFonts { Ascii = "Consolas", HighAnsi = "Consolas" },
+            FontSize = new FontSize { Val = "20" }
+        };
+        run.Append(runProps);
+        run.Append(new Text(codeBlock.Code) { Space = SpaceProcessingModeValues.Preserve });
+
+        paragraph.Append(run);
+        body.Append(paragraph);
+    }
+
+    private void AddBlockQuote(Body body, BlockQuoteElement blockQuote)
+    {
+        var paragraph = new Paragraph();
+        var props = new ParagraphProperties
+        {
+            Indentation = new Indentation { Left = "720" }, // 0.5 inch
+            ParagraphBorders = new ParagraphBorders
+            {
+                LeftBorder = new LeftBorder { Val = BorderValues.Single, Size = 12, Color = "CCCCCC" }
+            }
+        };
+        paragraph.Append(props);
+
+        var run = new Run();
+        var runProps = new RunProperties { Italic = new Italic() };
+        run.Append(runProps);
+        run.Append(new Text(blockQuote.Text) { Space = SpaceProcessingModeValues.Preserve });
+
+        paragraph.Append(run);
+        body.Append(paragraph);
+    }
+
+    private void AddHorizontalRule(Body body)
+    {
+        var paragraph = new Paragraph();
+        var props = new ParagraphProperties
+        {
+            ParagraphBorders = new ParagraphBorders
+            {
+                BottomBorder = new BottomBorder { Val = BorderValues.Single, Size = 6, Space = 1 }
+            }
+        };
+        paragraph.Append(props);
+        body.Append(paragraph);
+    }
+}

--- a/Mostlylucid.sln
+++ b/Mostlylucid.sln
@@ -86,6 +86,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mostlylucid.LlmAltText", "M
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mostlylucid.DocumentConversion", "Mostlylucid.DocumentConversion\Mostlylucid.DocumentConversion.csproj", "{D2C3B4A5-E6F7-4890-ABCD-EF1234567891}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mostlylucid.DocumentConversion.Demo", "Mostlylucid.DocumentConversion.Demo\Mostlylucid.DocumentConversion.Demo.csproj", "{E3D4C5B6-F7A8-4901-BCDE-F23456789012}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mostlylucid.DocumentConversion.Test", "Mostlylucid.DocumentConversion.Test\Mostlylucid.DocumentConversion.Test.csproj", "{F4E5D6C7-A8B9-4012-CDEF-345678901234}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -492,6 +496,30 @@ Global
 		{D2C3B4A5-E6F7-4890-ABCD-EF1234567891}.Release|x64.Build.0 = Release|Any CPU
 		{D2C3B4A5-E6F7-4890-ABCD-EF1234567891}.Release|x86.ActiveCfg = Release|Any CPU
 		{D2C3B4A5-E6F7-4890-ABCD-EF1234567891}.Release|x86.Build.0 = Release|Any CPU
+		{E3D4C5B6-F7A8-4901-BCDE-F23456789012}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E3D4C5B6-F7A8-4901-BCDE-F23456789012}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E3D4C5B6-F7A8-4901-BCDE-F23456789012}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E3D4C5B6-F7A8-4901-BCDE-F23456789012}.Debug|x64.Build.0 = Debug|Any CPU
+		{E3D4C5B6-F7A8-4901-BCDE-F23456789012}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E3D4C5B6-F7A8-4901-BCDE-F23456789012}.Debug|x86.Build.0 = Debug|Any CPU
+		{E3D4C5B6-F7A8-4901-BCDE-F23456789012}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E3D4C5B6-F7A8-4901-BCDE-F23456789012}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E3D4C5B6-F7A8-4901-BCDE-F23456789012}.Release|x64.ActiveCfg = Release|Any CPU
+		{E3D4C5B6-F7A8-4901-BCDE-F23456789012}.Release|x64.Build.0 = Release|Any CPU
+		{E3D4C5B6-F7A8-4901-BCDE-F23456789012}.Release|x86.ActiveCfg = Release|Any CPU
+		{E3D4C5B6-F7A8-4901-BCDE-F23456789012}.Release|x86.Build.0 = Release|Any CPU
+		{F4E5D6C7-A8B9-4012-CDEF-345678901234}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F4E5D6C7-A8B9-4012-CDEF-345678901234}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F4E5D6C7-A8B9-4012-CDEF-345678901234}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F4E5D6C7-A8B9-4012-CDEF-345678901234}.Debug|x64.Build.0 = Debug|Any CPU
+		{F4E5D6C7-A8B9-4012-CDEF-345678901234}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F4E5D6C7-A8B9-4012-CDEF-345678901234}.Debug|x86.Build.0 = Debug|Any CPU
+		{F4E5D6C7-A8B9-4012-CDEF-345678901234}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F4E5D6C7-A8B9-4012-CDEF-345678901234}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F4E5D6C7-A8B9-4012-CDEF-345678901234}.Release|x64.ActiveCfg = Release|Any CPU
+		{F4E5D6C7-A8B9-4012-CDEF-345678901234}.Release|x64.Build.0 = Release|Any CPU
+		{F4E5D6C7-A8B9-4012-CDEF-345678901234}.Release|x86.ActiveCfg = Release|Any CPU
+		{F4E5D6C7-A8B9-4012-CDEF-345678901234}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Mostlylucid.sln
+++ b/Mostlylucid.sln
@@ -84,6 +84,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mostlylucid.GeoDetection", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mostlylucid.LlmAltText", "Mostlylucid.LlmAltText\Mostlylucid.LlmAltText.csproj", "{E6F6BE46-36FA-447A-A13B-1152A283617C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mostlylucid.DocumentConversion", "Mostlylucid.DocumentConversion\Mostlylucid.DocumentConversion.csproj", "{D2C3B4A5-E6F7-4890-ABCD-EF1234567891}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -478,6 +480,18 @@ Global
 		{E6F6BE46-36FA-447A-A13B-1152A283617C}.Release|x64.Build.0 = Release|Any CPU
 		{E6F6BE46-36FA-447A-A13B-1152A283617C}.Release|x86.ActiveCfg = Release|Any CPU
 		{E6F6BE46-36FA-447A-A13B-1152A283617C}.Release|x86.Build.0 = Release|Any CPU
+		{D2C3B4A5-E6F7-4890-ABCD-EF1234567891}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D2C3B4A5-E6F7-4890-ABCD-EF1234567891}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D2C3B4A5-E6F7-4890-ABCD-EF1234567891}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D2C3B4A5-E6F7-4890-ABCD-EF1234567891}.Debug|x64.Build.0 = Debug|Any CPU
+		{D2C3B4A5-E6F7-4890-ABCD-EF1234567891}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D2C3B4A5-E6F7-4890-ABCD-EF1234567891}.Debug|x86.Build.0 = Debug|Any CPU
+		{D2C3B4A5-E6F7-4890-ABCD-EF1234567891}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D2C3B4A5-E6F7-4890-ABCD-EF1234567891}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D2C3B4A5-E6F7-4890-ABCD-EF1234567891}.Release|x64.ActiveCfg = Release|Any CPU
+		{D2C3B4A5-E6F7-4890-ABCD-EF1234567891}.Release|x64.Build.0 = Release|Any CPU
+		{D2C3B4A5-E6F7-4890-ABCD-EF1234567891}.Release|x86.ActiveCfg = Release|Any CPU
+		{D2C3B4A5-E6F7-4890-ABCD-EF1234567891}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Mostlylucid/Markdown/multi-format-document-conversion-service.md
+++ b/Mostlylucid/Markdown/multi-format-document-conversion-service.md
@@ -1,0 +1,608 @@
+# Building a Multi-Format Document Conversion Service for .NET
+
+## Introduction
+
+Document conversion is a common requirement in many applications - from content management systems to report generators. Whether you need to convert Word documents to PDF, transform Markdown to Word, or extract content from various document formats, having a reliable, free, and open-source solution is invaluable.
+
+This article introduces **Mostlylucid.DocumentConversion**, a comprehensive document conversion library for .NET 9.0 that supports multiple formats including Word (.docx), Markdown, PDF, HTML, and plain text. Unlike commercial solutions that can cost hundreds of dollars per month, this library uses entirely free and open-source components.
+
+[TOC]
+
+<!--category-- ASP.NET, Document Processing, PDF, Markdown, Open Source -->
+<datetime class="hidden">2025-01-22T12:00</datetime>
+
+## Why Build a Document Conversion Library?
+
+Existing .NET document conversion solutions typically fall into two categories:
+
+1. **Commercial Libraries**: Aspose, Syncfusion, and similar products offer comprehensive features but come with significant licensing costs ($999-$5,999+ per developer)
+
+2. **Limited Free Options**: Basic libraries that handle only one format or lack important features like formatting preservation
+
+This library fills the gap by providing:
+
+- **Multi-Format Support**: Read Word, Markdown, plain text; write Word, Markdown, PDF, HTML, plain text
+- **Element Extraction**: Parse documents into structured elements (headings, paragraphs, tables, lists, images)
+- **Formatting Preservation**: Maintain bold, italic, underline, links, and other styling
+- **PDF Generation**: High-quality PDF output with customizable page sizes and orientations
+- **100% Free**: All dependencies use MIT, BSD, or similar permissive licenses
+
+## Architecture Overview
+
+The library is built on a modular service pattern where each format has its own specialized service:
+
+```mermaid
+graph TB
+    Client[Client Code] --> Main[DocumentConversionService]
+    Main --> Word[WordDocumentService]
+    Main --> MD[MarkdownConversionService]
+    Main --> PDF[PdfConversionService]
+
+    Word -->|OpenXML| DOCX[.docx files]
+    MD -->|Markdig| MDFiles[.md files]
+    PDF -->|QuestPDF| PDFFiles[.pdf files]
+
+    subgraph "Document Model"
+        Doc[Document]
+        Doc --> Elements[DocumentElement]
+        Elements --> Heading[HeadingElement]
+        Elements --> Para[ParagraphElement]
+        Elements --> Table[TableElement]
+        Elements --> List[ListElement]
+        Elements --> Image[ImageElement]
+        Elements --> Code[CodeBlockElement]
+    end
+```
+
+## Core Components
+
+### 1. The Document Model
+
+At the heart of the library is a unified document model that represents content from any source format:
+
+```csharp
+public class Document
+{
+    public string? Title { get; set; }
+    public string? Author { get; set; }
+    public DateTime? CreatedDate { get; set; }
+    public DocumentFormat SourceFormat { get; set; }
+    public List<DocumentElement> Elements { get; set; } = [];
+    public List<ImageElement> Images { get; set; } = [];
+
+    public string GetPlainText() { /* ... */ }
+    public int GetWordCount() { /* ... */ }
+    public IEnumerable<HeadingElement> GetHeadings() { /* ... */ }
+}
+```
+
+Each document contains a list of `DocumentElement` objects representing different content types:
+
+```csharp
+public abstract class DocumentElement
+{
+    public string Id { get; set; }
+    public abstract DocumentElementType ElementType { get; }
+    public int Order { get; set; }
+}
+
+// Concrete implementations
+public class HeadingElement : DocumentElement
+{
+    public int Level { get; set; }  // 1-6
+    public string Text { get; set; }
+    public List<TextRun> Runs { get; set; }  // Formatted text spans
+}
+
+public class ParagraphElement : DocumentElement
+{
+    public string Text { get; set; }
+    public List<TextRun> Runs { get; set; }
+    public TextAlignment Alignment { get; set; }
+}
+
+public class TableElement : DocumentElement
+{
+    public List<TableRow> Rows { get; set; }
+    public bool HasHeaderRow { get; set; }
+}
+
+// Plus: ListElement, ImageElement, CodeBlockElement, BlockQuoteElement, etc.
+```
+
+### 2. Text Formatting with TextRun
+
+The `TextRun` class captures text formatting at the character level:
+
+```csharp
+public class TextRun
+{
+    public string Text { get; set; }
+    public bool IsBold { get; set; }
+    public bool IsItalic { get; set; }
+    public bool IsUnderline { get; set; }
+    public bool IsStrikethrough { get; set; }
+    public bool IsCode { get; set; }
+    public string? HyperlinkUrl { get; set; }
+    public string? FontName { get; set; }
+    public double? FontSize { get; set; }
+    public string? Color { get; set; }
+}
+```
+
+This allows preserving rich formatting when converting between formats that support it.
+
+## Libraries Used
+
+The library relies on three excellent open-source packages:
+
+| Library | Version | Purpose | License |
+|---------|---------|---------|---------|
+| **DocumentFormat.OpenXml** | 3.2.0 | Word document reading/writing | MIT |
+| **Markdig** | 0.43.0 | Markdown parsing and generation | BSD-2-Clause |
+| **QuestPDF** | 2024.12.3 | PDF generation | Community (free) |
+
+### Why These Libraries?
+
+**DocumentFormat.OpenXml** is Microsoft's official library for working with Office Open XML formats. It provides low-level access to Word documents without requiring Microsoft Office to be installed. The API is verbose but complete, giving full control over document structure.
+
+**Markdig** is the most comprehensive Markdown parser for .NET. It supports GitHub Flavored Markdown, tables, task lists, and many extensions. It's actively maintained and highly performant.
+
+**QuestPDF** is a modern PDF generation library with a fluent API. The Community license is completely free for commercial use. It excels at creating structured documents with tables, images, and consistent styling.
+
+## Service Implementations
+
+### Word Document Service
+
+The `WordDocumentService` handles reading and writing `.docx` files using the Open XML SDK:
+
+```csharp
+public class WordDocumentService : IWordDocumentService
+{
+    public Task<Document> ReadAsync(Stream stream, string? fileName = null,
+        CancellationToken ct = default)
+    {
+        return Task.Run(() =>
+        {
+            var document = new Document { SourceFormat = DocumentFormat.Word };
+
+            using var wordDoc = WordprocessingDocument.Open(stream, false);
+            var mainPart = wordDoc.MainDocumentPart;
+
+            // Extract metadata
+            ExtractMetadata(wordDoc, document);
+
+            // Parse body elements
+            var body = mainPart?.Document?.Body;
+            if (body != null)
+            {
+                int order = 0;
+                foreach (var element in body.Elements())
+                {
+                    var extracted = ExtractElement(element, mainPart, ref order);
+                    if (extracted != null)
+                        document.Elements.Add(extracted);
+                }
+            }
+
+            return document;
+        }, ct);
+    }
+
+    private DocumentElement? ExtractElement(OpenXmlElement element,
+        MainDocumentPart mainPart, ref int order)
+    {
+        return element switch
+        {
+            Paragraph p => ExtractParagraph(p, mainPart, ref order),
+            Table t => ExtractTable(t, mainPart, ref order),
+            _ => null
+        };
+    }
+}
+```
+
+**Key Features:**
+- Extracts document metadata (title, author, dates)
+- Identifies heading levels from paragraph styles
+- Preserves text formatting (bold, italic, underline)
+- Extracts embedded images with content type detection
+- Handles hyperlinks with URL extraction
+- Parses tables with header row detection
+
+### Markdown Conversion Service
+
+The `MarkdownConversionService` uses Markdig to parse and generate Markdown:
+
+```csharp
+public class MarkdownConversionService : IMarkdownConversionService
+{
+    private readonly MarkdownPipeline _pipeline;
+
+    public MarkdownConversionService(ILogger<MarkdownConversionService> logger)
+    {
+        _pipeline = new MarkdownPipelineBuilder()
+            .UseAdvancedExtensions()
+            .UsePipeTables()
+            .UseAutoLinks()
+            .UseEmphasisExtras()
+            .UseTaskLists()
+            .Build();
+    }
+
+    public Task<Document> ParseAsync(string markdown, string? fileName = null,
+        CancellationToken ct = default)
+    {
+        return Task.Run(() =>
+        {
+            var document = new Document { SourceFormat = DocumentFormat.Markdown };
+            var markdownDoc = Markdown.Parse(markdown, _pipeline);
+
+            int order = 0;
+            foreach (var block in markdownDoc)
+            {
+                var element = ConvertBlock(block, ref order);
+                if (element != null)
+                    document.Elements.Add(element);
+            }
+
+            return document;
+        }, ct);
+    }
+
+    private DocumentElement? ConvertBlock(Block block, ref int order)
+    {
+        return block switch
+        {
+            HeadingBlock h => new HeadingElement
+            {
+                Level = h.Level,
+                Text = GetInlineText(h.Inline),
+                Order = order++
+            },
+            ParagraphBlock p => new ParagraphElement
+            {
+                Text = GetInlineText(p.Inline),
+                Runs = GetInlineRuns(p.Inline),
+                Order = order++
+            },
+            FencedCodeBlock c => new CodeBlockElement
+            {
+                Code = GetCodeBlockContent(c),
+                Language = c.Info,
+                Order = order++
+            },
+            // ... more block types
+            _ => null
+        };
+    }
+}
+```
+
+**Key Features:**
+- Full GitHub Flavored Markdown support
+- Inline formatting detection (bold, italic, code)
+- Link and image extraction
+- Code block language detection
+- Table parsing with column spans
+- Nested list handling
+
+### PDF Conversion Service
+
+The `PdfConversionService` uses QuestPDF to generate high-quality PDFs:
+
+```csharp
+public class PdfConversionService : IPdfConversionService
+{
+    public Task<byte[]> ToPdfAsync(Document document,
+        ConversionOptions? options = null, CancellationToken ct = default)
+    {
+        return Task.Run(() =>
+        {
+            QuestPDF.Settings.License = LicenseType.Community;
+
+            var pdfDocument = Document.Create(container =>
+            {
+                container.Page(page =>
+                {
+                    ConfigurePage(page, options);
+                    page.Header().Element(h => RenderHeader(h, document));
+                    page.Content().Element(c => RenderContent(c, document, options));
+                    page.Footer().Element(f => RenderFooter(f));
+                });
+            });
+
+            return pdfDocument.GeneratePdf();
+        }, ct);
+    }
+
+    private void RenderElement(IContainer container, DocumentElement element,
+        ConversionOptions? options)
+    {
+        switch (element)
+        {
+            case HeadingElement h:
+                var fontSize = h.Level switch { 1 => 24f, 2 => 20f, 3 => 16f, _ => 14f };
+                container.Text(h.Text).FontSize(fontSize).Bold();
+                break;
+
+            case ParagraphElement p:
+                container.Text(text => RenderTextRuns(text, p.Runs));
+                break;
+
+            case TableElement t:
+                RenderTable(container, t);
+                break;
+
+            case CodeBlockElement c:
+                container.Background(Colors.Grey.Lighten4)
+                    .Padding(10)
+                    .Text(c.Code).FontFamily("Courier New").FontSize(10);
+                break;
+            // ... more element types
+        }
+    }
+}
+```
+
+**Key Features:**
+- Configurable page size (A3, A4, A5, Letter, Legal)
+- Portrait and landscape orientation
+- Header with document title
+- Footer with page numbers
+- Proper heading hierarchy with font sizes
+- Table rendering with borders and header styling
+- Code block styling with monospace font
+- Image embedding with aspect ratio preservation
+- Block quote styling with left border
+
+## Usage Examples
+
+### Basic Setup
+
+Register the services in your `Program.cs`:
+
+```csharp
+using Mostlylucid.DocumentConversion.Extensions;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add document conversion services
+builder.Services.AddDocumentConversion();
+
+var app = builder.Build();
+```
+
+### Word to Markdown Conversion
+
+```csharp
+public class DocumentController : ControllerBase
+{
+    private readonly IDocumentConversionService _converter;
+
+    [HttpPost("word-to-markdown")]
+    public async Task<IActionResult> ConvertWordToMarkdown(IFormFile file)
+    {
+        await using var stream = file.OpenReadStream();
+        var markdown = await _converter.WordToMarkdownAsync(stream);
+
+        return Ok(new { markdown });
+    }
+}
+```
+
+### Markdown to PDF Conversion
+
+```csharp
+[HttpPost("markdown-to-pdf")]
+public async Task<IActionResult> ConvertMarkdownToPdf([FromBody] string markdown)
+{
+    var options = new ConversionOptions
+    {
+        PageSize = PdfPageSize.A4,
+        Orientation = PdfOrientation.Portrait,
+        IncludeImages = true
+    };
+
+    var pdfBytes = await _converter.MarkdownToPdfAsync(markdown, options);
+
+    return File(pdfBytes, "application/pdf", "document.pdf");
+}
+```
+
+### Element Extraction
+
+```csharp
+[HttpPost("extract-elements")]
+public async Task<IActionResult> ExtractElements(IFormFile file)
+{
+    await using var stream = file.OpenReadStream();
+    var elements = await _converter.ExtractElementsAsync(stream, file.FileName);
+
+    return Ok(new
+    {
+        elementCount = elements.Count,
+        headings = elements.OfType<HeadingElement>().Select(h => h.Text),
+        tables = elements.OfType<TableElement>().Count(),
+        images = elements.OfType<ImageElement>().Count()
+    });
+}
+```
+
+### Full Document Processing
+
+```csharp
+// Read any supported format
+var document = await _converter.ReadDocumentAsync(stream, "report.docx");
+
+// Access document properties
+Console.WriteLine($"Title: {document.Title}");
+Console.WriteLine($"Word count: {document.GetWordCount()}");
+Console.WriteLine($"Headings: {document.GetHeadings().Count()}");
+
+// Convert to multiple formats
+var markdownResult = await _converter.ConvertAsync(document, DocumentFormat.Markdown);
+var pdfResult = await _converter.ConvertAsync(document, DocumentFormat.Pdf);
+var htmlResult = await _converter.ConvertAsync(document, DocumentFormat.Html);
+
+// Save results
+await File.WriteAllTextAsync("output.md", markdownResult.OutputText);
+await File.WriteAllBytesAsync("output.pdf", pdfResult.OutputBytes);
+```
+
+## Conversion Options
+
+The `ConversionOptions` class provides fine-grained control over the conversion process:
+
+```csharp
+public class ConversionOptions
+{
+    public bool IncludeImages { get; set; } = true;
+    public bool IncludeTables { get; set; } = true;
+    public bool IncludeMetadata { get; set; } = true;
+    public bool PreserveFormatting { get; set; } = true;
+
+    // PDF-specific
+    public PdfPageSize PageSize { get; set; } = PdfPageSize.A4;
+    public PdfOrientation Orientation { get; set; } = PdfOrientation.Portrait;
+
+    // Markdown-specific
+    public bool UseGitHubFlavoredMarkdown { get; set; } = true;
+
+    // Image handling
+    public bool EmbedImagesAsDataUri { get; set; } = true;
+    public string? ImageOutputDirectory { get; set; }
+
+    // HTML-specific
+    public string? CustomCss { get; set; }
+}
+```
+
+## Supported Conversions
+
+| From | To |
+|------|-----|
+| Word (.docx) | Markdown, PDF, HTML, Plain Text |
+| Markdown (.md) | Word, PDF, HTML, Plain Text |
+| Plain Text (.txt) | Word, Markdown, PDF, HTML |
+
+**Note:** PDF is output-only; reading PDF content is not supported as it would require OCR or text extraction capabilities beyond the scope of this library.
+
+## Performance Considerations
+
+The library is designed for efficiency:
+
+- **Async/Await**: All operations are fully asynchronous
+- **Streaming**: File operations use streams to minimize memory usage
+- **No Office Required**: Works without Microsoft Office installation
+- **Thread-Safe**: Services can be registered as singletons for high-throughput scenarios
+
+For high-throughput scenarios, use the singleton registration:
+
+```csharp
+builder.Services.AddDocumentConversionSingleton();
+```
+
+## Error Handling
+
+The library uses a result pattern for conversion operations:
+
+```csharp
+public class ConversionResult
+{
+    public bool Success { get; set; }
+    public string? ErrorMessage { get; set; }
+    public byte[]? OutputBytes { get; set; }
+    public string? OutputText { get; set; }
+    public DocumentFormat OutputFormat { get; set; }
+    public string? ContentType { get; set; }
+    public List<string> Warnings { get; set; }
+}
+```
+
+Example error handling:
+
+```csharp
+var result = await _converter.ConvertAsync(document, DocumentFormat.Pdf);
+
+if (!result.Success)
+{
+    _logger.LogError("Conversion failed: {Error}", result.ErrorMessage);
+    return BadRequest(result.ErrorMessage);
+}
+
+if (result.Warnings.Any())
+{
+    _logger.LogWarning("Conversion warnings: {Warnings}",
+        string.Join(", ", result.Warnings));
+}
+
+return File(result.OutputBytes!, result.ContentType!, "output.pdf");
+```
+
+## Limitations
+
+- **PDF Reading**: Not supported (would require OCR)
+- **Legacy Word (.doc)**: Not supported; convert to .docx first
+- **Complex Word Features**: Some advanced features like track changes, comments, and complex nested tables may not be fully preserved
+- **Fonts in PDF**: Uses standard fonts; custom fonts require additional configuration
+
+## Testing
+
+The library includes comprehensive unit tests:
+
+```bash
+dotnet test Mostlylucid.DocumentConversion.Test
+```
+
+Test coverage includes:
+- Markdown parsing and generation
+- Document model operations
+- Format detection
+- Conversion result handling
+- Element type detection
+
+## Demo Application
+
+A demo web application is included to try out all features:
+
+```bash
+cd Mostlylucid.DocumentConversion.Demo
+dotnet run
+```
+
+Navigate to `http://localhost:5000` to access the demo UI with:
+- Word to Markdown conversion
+- Word to PDF conversion
+- Markdown to Word conversion
+- Markdown to PDF conversion
+- Element extraction
+- Image extraction
+
+## Conclusion
+
+The Mostlylucid.DocumentConversion library provides a comprehensive, free solution for document conversion in .NET applications. By leveraging well-maintained open-source libraries like OpenXML SDK, Markdig, and QuestPDF, it offers reliable conversions without licensing costs.
+
+Key benefits:
+- **Free**: No licensing fees, all dependencies use permissive licenses
+- **Comprehensive**: Supports multiple formats with formatting preservation
+- **Extensible**: Modular architecture allows adding custom processors
+- **Tested**: Includes unit tests and a demo application
+- **Modern**: Built for .NET 9.0 with async/await throughout
+
+Whether you're building a content management system, generating reports, or need document processing in your application, this library provides a solid foundation without the cost of commercial alternatives.
+
+## Source Code
+
+The complete source code is available in the Mostlylucid repository:
+
+- Library: `/Mostlylucid.DocumentConversion`
+- Demo: `/Mostlylucid.DocumentConversion.Demo`
+- Tests: `/Mostlylucid.DocumentConversion.Test`
+
+## Further Reading
+
+- [Open XML SDK Documentation](https://docs.microsoft.com/en-us/office/open-xml/open-xml-sdk)
+- [Markdig GitHub Repository](https://github.com/xoofx/markdig)
+- [QuestPDF Documentation](https://www.questpdf.com/)
+- [Office Open XML File Formats](https://en.wikipedia.org/wiki/Office_Open_XML)


### PR DESCRIPTION
Add Mostlylucid.DocumentConversion project with support for:
- Word documents (.docx) read/write using Open XML SDK
- Markdown parsing and generation using Markdig
- PDF generation using QuestPDF (community license)
- Element extraction (headings, paragraphs, tables, lists, images, code blocks)
- Document model with metadata and conversion options
- DI extension methods for easy integration