### PR TITLE
Build Archive.org downloader with date range

### DIFF
--- a/Mostlylucid.ArchiveOrg/Config/ArchiveOrgOptions.cs
+++ b/Mostlylucid.ArchiveOrg/Config/ArchiveOrgOptions.cs
@@ -1,0 +1,64 @@
+namespace Mostlylucid.ArchiveOrg.Config;
+
+public class ArchiveOrgOptions
+{
+    public const string SectionName = "ArchiveOrg";
+
+    /// <summary>
+    /// The base URL of the website to download from Archive.org
+    /// e.g., "https://example.com"
+    /// </summary>
+    public string TargetUrl { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Optional: Only download snapshots up to this date (inclusive)
+    /// Format: yyyy-MM-dd
+    /// </summary>
+    public DateTime? EndDate { get; set; }
+
+    /// <summary>
+    /// Optional: Only download snapshots from this date (inclusive)
+    /// </summary>
+    public DateTime? StartDate { get; set; }
+
+    /// <summary>
+    /// Output directory for downloaded HTML files
+    /// </summary>
+    public string OutputDirectory { get; set; } = "./archive-output";
+
+    /// <summary>
+    /// Rate limit: milliseconds between requests to Archive.org
+    /// Default: 5000ms (5 seconds) to be respectful of their limits
+    /// </summary>
+    public int RateLimitMs { get; set; } = 5000;
+
+    /// <summary>
+    /// Maximum concurrent downloads (keep low to respect rate limits)
+    /// </summary>
+    public int MaxConcurrentDownloads { get; set; } = 1;
+
+    /// <summary>
+    /// URL patterns to include (regex). If empty, all URLs are included.
+    /// </summary>
+    public List<string> IncludePatterns { get; set; } = [];
+
+    /// <summary>
+    /// URL patterns to exclude (regex)
+    /// </summary>
+    public List<string> ExcludePatterns { get; set; } = [];
+
+    /// <summary>
+    /// Only download unique URLs (latest snapshot per URL)
+    /// </summary>
+    public bool UniqueUrlsOnly { get; set; } = true;
+
+    /// <summary>
+    /// MIME types to include
+    /// </summary>
+    public List<string> MimeTypes { get; set; } = ["text/html"];
+
+    /// <summary>
+    /// HTTP status codes to include
+    /// </summary>
+    public List<int> StatusCodes { get; set; } = [200];
+}

--- a/Mostlylucid.ArchiveOrg/Config/MarkdownConversionOptions.cs
+++ b/Mostlylucid.ArchiveOrg/Config/MarkdownConversionOptions.cs
@@ -1,0 +1,68 @@
+namespace Mostlylucid.ArchiveOrg.Config;
+
+public class MarkdownConversionOptions
+{
+    public const string SectionName = "MarkdownConversion";
+
+    /// <summary>
+    /// Input directory containing HTML files to convert
+    /// </summary>
+    public string InputDirectory { get; set; } = "./archive-output";
+
+    /// <summary>
+    /// Output directory for converted markdown files
+    /// </summary>
+    public string OutputDirectory { get; set; } = "./markdown-output";
+
+    /// <summary>
+    /// CSS selector for the main content area to extract
+    /// e.g., "article", ".post-content", "#main-content"
+    /// If empty, attempts to auto-detect main content
+    /// </summary>
+    public string ContentSelector { get; set; } = string.Empty;
+
+    /// <summary>
+    /// CSS selectors to remove from the content before conversion
+    /// e.g., navigation, ads, footers, sidebars
+    /// </summary>
+    public List<string> RemoveSelectors { get; set; } =
+    [
+        "nav",
+        "header",
+        "footer",
+        ".sidebar",
+        ".advertisement",
+        ".ads",
+        ".comments",
+        ".social-share",
+        "script",
+        "style",
+        "noscript",
+        "iframe"
+    ];
+
+    /// <summary>
+    /// Whether to generate tags using LLM
+    /// </summary>
+    public bool GenerateTags { get; set; } = true;
+
+    /// <summary>
+    /// Whether to extract/infer publish date from content
+    /// </summary>
+    public bool ExtractDates { get; set; } = true;
+
+    /// <summary>
+    /// File extension pattern to process
+    /// </summary>
+    public string FilePattern { get; set; } = "*.html";
+
+    /// <summary>
+    /// Whether to preserve images (download and update paths)
+    /// </summary>
+    public bool PreserveImages { get; set; } = true;
+
+    /// <summary>
+    /// Directory for downloaded images (relative to markdown output)
+    /// </summary>
+    public string ImagesDirectory { get; set; } = "images";
+}

--- a/Mostlylucid.ArchiveOrg/Config/OllamaOptions.cs
+++ b/Mostlylucid.ArchiveOrg/Config/OllamaOptions.cs
@@ -1,0 +1,37 @@
+namespace Mostlylucid.ArchiveOrg.Config;
+
+public class OllamaOptions
+{
+    public const string SectionName = "Ollama";
+
+    /// <summary>
+    /// Ollama API endpoint
+    /// </summary>
+    public string BaseUrl { get; set; } = "http://localhost:11434";
+
+    /// <summary>
+    /// Model to use for tag generation (e.g., "llama3.2", "mistral", "phi3")
+    /// </summary>
+    public string Model { get; set; } = "llama3.2";
+
+    /// <summary>
+    /// Temperature for generation (0.0 - 1.0)
+    /// Lower = more deterministic
+    /// </summary>
+    public float Temperature { get; set; } = 0.3f;
+
+    /// <summary>
+    /// Maximum number of tags to generate
+    /// </summary>
+    public int MaxTags { get; set; } = 5;
+
+    /// <summary>
+    /// Timeout for LLM requests in seconds
+    /// </summary>
+    public int TimeoutSeconds { get; set; } = 60;
+
+    /// <summary>
+    /// Whether Ollama integration is enabled
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+}

--- a/Mostlylucid.ArchiveOrg/Models/CdxRecord.cs
+++ b/Mostlylucid.ArchiveOrg/Models/CdxRecord.cs
@@ -1,0 +1,96 @@
+namespace Mostlylucid.ArchiveOrg.Models;
+
+/// <summary>
+/// Represents a single record from the Archive.org CDX API
+/// CDX format: urlkey, timestamp, original, mimetype, statuscode, digest, length
+/// </summary>
+public class CdxRecord
+{
+    /// <summary>
+    /// SURT-format URL key
+    /// </summary>
+    public string UrlKey { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Archive timestamp in format: yyyyMMddHHmmss
+    /// </summary>
+    public string Timestamp { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Original URL that was archived
+    /// </summary>
+    public string OriginalUrl { get; set; } = string.Empty;
+
+    /// <summary>
+    /// MIME type of the archived content
+    /// </summary>
+    public string MimeType { get; set; } = string.Empty;
+
+    /// <summary>
+    /// HTTP status code when archived
+    /// </summary>
+    public int StatusCode { get; set; }
+
+    /// <summary>
+    /// Content digest/hash
+    /// </summary>
+    public string Digest { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Content length in bytes
+    /// </summary>
+    public long Length { get; set; }
+
+    /// <summary>
+    /// Parsed datetime from the timestamp
+    /// </summary>
+    public DateTime ArchiveDate => ParseTimestamp(Timestamp);
+
+    /// <summary>
+    /// Full Wayback Machine URL to access this snapshot
+    /// </summary>
+    public string WaybackUrl => $"https://web.archive.org/web/{Timestamp}/{OriginalUrl}";
+
+    /// <summary>
+    /// Raw Wayback Machine URL (without replay modifications)
+    /// </summary>
+    public string WaybackRawUrl => $"https://web.archive.org/web/{Timestamp}id_/{OriginalUrl}";
+
+    private static DateTime ParseTimestamp(string timestamp)
+    {
+        if (string.IsNullOrEmpty(timestamp) || timestamp.Length < 14)
+            return DateTime.MinValue;
+
+        if (DateTime.TryParseExact(
+                timestamp[..14],
+                "yyyyMMddHHmmss",
+                null,
+                System.Globalization.DateTimeStyles.None,
+                out var result))
+        {
+            return result;
+        }
+
+        return DateTime.MinValue;
+    }
+
+    /// <summary>
+    /// Parse a CDX API JSON array row into a CdxRecord
+    /// </summary>
+    public static CdxRecord FromJsonArray(string[] fields)
+    {
+        if (fields.Length < 7)
+            throw new ArgumentException("CDX record requires at least 7 fields");
+
+        return new CdxRecord
+        {
+            UrlKey = fields[0],
+            Timestamp = fields[1],
+            OriginalUrl = fields[2],
+            MimeType = fields[3],
+            StatusCode = int.TryParse(fields[4], out var code) ? code : 0,
+            Digest = fields[5],
+            Length = long.TryParse(fields[6], out var len) ? len : 0
+        };
+    }
+}

--- a/Mostlylucid.ArchiveOrg/Models/DownloadResult.cs
+++ b/Mostlylucid.ArchiveOrg/Models/DownloadResult.cs
@@ -1,0 +1,34 @@
+namespace Mostlylucid.ArchiveOrg.Models;
+
+/// <summary>
+/// Result of downloading an archived page
+/// </summary>
+public class DownloadResult
+{
+    public bool Success { get; set; }
+    public string OriginalUrl { get; set; } = string.Empty;
+    public DateTime ArchiveDate { get; set; }
+    public string? FilePath { get; set; }
+    public string? HtmlContent { get; set; }
+    public string? ErrorMessage { get; set; }
+    public CdxRecord? CdxRecord { get; set; }
+
+    public static DownloadResult Failed(CdxRecord record, string error) => new()
+    {
+        Success = false,
+        OriginalUrl = record.OriginalUrl,
+        ArchiveDate = record.ArchiveDate,
+        ErrorMessage = error,
+        CdxRecord = record
+    };
+
+    public static DownloadResult Succeeded(CdxRecord record, string filePath, string? content = null) => new()
+    {
+        Success = true,
+        OriginalUrl = record.OriginalUrl,
+        ArchiveDate = record.ArchiveDate,
+        FilePath = filePath,
+        HtmlContent = content,
+        CdxRecord = record
+    };
+}

--- a/Mostlylucid.ArchiveOrg/Models/MarkdownArticle.cs
+++ b/Mostlylucid.ArchiveOrg/Models/MarkdownArticle.cs
@@ -1,0 +1,83 @@
+namespace Mostlylucid.ArchiveOrg.Models;
+
+/// <summary>
+/// Represents a converted markdown article ready for blog import
+/// </summary>
+public class MarkdownArticle
+{
+    /// <summary>
+    /// Article title extracted from HTML
+    /// </summary>
+    public string Title { get; set; } = string.Empty;
+
+    /// <summary>
+    /// URL slug for the article
+    /// </summary>
+    public string Slug { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Original URL of the archived page
+    /// </summary>
+    public string OriginalUrl { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Archive.org snapshot date
+    /// </summary>
+    public DateTime ArchiveDate { get; set; }
+
+    /// <summary>
+    /// Inferred/extracted publish date (may differ from archive date)
+    /// </summary>
+    public DateTime? PublishDate { get; set; }
+
+    /// <summary>
+    /// Categories/tags for the article
+    /// </summary>
+    public List<string> Categories { get; set; } = [];
+
+    /// <summary>
+    /// The markdown content
+    /// </summary>
+    public string MarkdownContent { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Source HTML file path
+    /// </summary>
+    public string SourceFilePath { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Output markdown file path
+    /// </summary>
+    public string OutputFilePath { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Images found and downloaded
+    /// </summary>
+    public List<ImageInfo> Images { get; set; } = [];
+
+    /// <summary>
+    /// Generate the full markdown file content with frontmatter
+    /// Compatible with the Mostlylucid blog format
+    /// </summary>
+    public string ToFullMarkdown()
+    {
+        var effectiveDate = PublishDate ?? ArchiveDate;
+        var categories = Categories.Count > 0 ? string.Join(", ", Categories) : "Imported";
+
+        return $"""
+                # {Title}
+                <!-- category -- {categories} -->
+                <datetime class="hidden">{effectiveDate:yyyy-MM-ddTHH:mm}</datetime>
+
+                {MarkdownContent}
+                """;
+    }
+}
+
+public class ImageInfo
+{
+    public string OriginalUrl { get; set; } = string.Empty;
+    public string LocalPath { get; set; } = string.Empty;
+    public string MarkdownPath { get; set; } = string.Empty;
+    public bool Downloaded { get; set; }
+}

--- a/Mostlylucid.ArchiveOrg/Mostlylucid.ArchiveOrg.csproj
+++ b/Mostlylucid.ArchiveOrg/Mostlylucid.ArchiveOrg.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net9.0</TargetFramework>
+        <LangVersion>12</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="HtmlAgilityPack" Version="1.11.72" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.0" />
+        <PackageReference Include="Polly" Version="8.6.3" />
+        <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
+        <PackageReference Include="ReverseMarkdown" Version="4.6.0" />
+        <PackageReference Include="Serilog" Version="4.1.0" />
+        <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />
+        <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+        <PackageReference Include="System.Text.Json" Version="9.0.0" />
+    </ItemGroup>
+
+</Project>

--- a/Mostlylucid.ArchiveOrg/Program.cs
+++ b/Mostlylucid.ArchiveOrg/Program.cs
@@ -1,0 +1,207 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Mostlylucid.ArchiveOrg;
+using Mostlylucid.ArchiveOrg.Config;
+using Mostlylucid.ArchiveOrg.Services;
+using Serilog;
+
+// Build configuration
+var configuration = new ConfigurationBuilder()
+    .SetBasePath(Directory.GetCurrentDirectory())
+    .AddJsonFile("appsettings.json", optional: true)
+    .AddJsonFile($"appsettings.{Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT") ?? "Production"}.json", optional: true)
+    .AddEnvironmentVariables()
+    .AddCommandLine(args)
+    .Build();
+
+// Configure Serilog
+Log.Logger = new LoggerConfiguration()
+    .ReadFrom.Configuration(configuration)
+    .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}")
+    .CreateLogger();
+
+try
+{
+    Log.Information("Archive.org Downloader starting...");
+
+    // Build host
+    var host = Host.CreateDefaultBuilder(args)
+        .UseSerilog()
+        .ConfigureServices((context, services) =>
+        {
+            services.AddArchiveOrgServices(configuration);
+        })
+        .Build();
+
+    // Parse command
+    var command = args.Length > 0 ? args[0].ToLower() : "help";
+
+    switch (command)
+    {
+        case "download":
+            await RunDownloadAsync(host.Services);
+            break;
+
+        case "convert":
+            await RunConvertAsync(host.Services);
+            break;
+
+        case "full":
+            await RunFullPipelineAsync(host.Services);
+            break;
+
+        case "help":
+        default:
+            PrintHelp();
+            break;
+    }
+
+    Log.Information("Archive.org Downloader completed");
+}
+catch (Exception ex)
+{
+    Log.Fatal(ex, "Application terminated unexpectedly");
+    return 1;
+}
+finally
+{
+    await Log.CloseAndFlushAsync();
+}
+
+return 0;
+
+static async Task RunDownloadAsync(IServiceProvider services)
+{
+    var downloader = services.GetRequiredService<IArchiveDownloader>();
+    var options = services.GetRequiredService<Microsoft.Extensions.Options.IOptions<ArchiveOrgOptions>>().Value;
+    var logger = services.GetRequiredService<ILogger<Program>>();
+
+    logger.LogInformation("Starting download from Archive.org");
+    logger.LogInformation("Target URL: {Url}", options.TargetUrl);
+    logger.LogInformation("Output Directory: {Dir}", options.OutputDirectory);
+
+    if (options.EndDate.HasValue)
+        logger.LogInformation("End Date: {Date:yyyy-MM-dd}", options.EndDate);
+    if (options.StartDate.HasValue)
+        logger.LogInformation("Start Date: {Date:yyyy-MM-dd}", options.StartDate);
+    else
+        logger.LogInformation("Start Date: (none - fetching ALL available archives)");
+
+    logger.LogInformation("Rate Limit: {Ms}ms between requests", options.RateLimitMs);
+
+    var progress = new Progress<DownloadProgress>(p =>
+    {
+        if (p.ProcessedRecords % 10 == 0 || p.ProcessedRecords == p.TotalRecords)
+        {
+            logger.LogInformation(
+                "Download Progress: {Processed}/{Total} ({Percent:F1}%) - Success: {Success}, Failed: {Failed}",
+                p.ProcessedRecords, p.TotalRecords, p.PercentComplete,
+                p.SuccessfulDownloads, p.FailedDownloads);
+        }
+    });
+
+    var results = await downloader.DownloadAllAsync(progress);
+
+    logger.LogInformation("Download complete. Total: {Total}, Success: {Success}, Failed: {Failed}",
+        results.Count,
+        results.Count(r => r.Success),
+        results.Count(r => !r.Success));
+}
+
+static async Task RunConvertAsync(IServiceProvider services)
+{
+    var converter = services.GetRequiredService<IHtmlToMarkdownConverter>();
+    var options = services.GetRequiredService<Microsoft.Extensions.Options.IOptions<MarkdownConversionOptions>>().Value;
+    var logger = services.GetRequiredService<ILogger<Program>>();
+
+    logger.LogInformation("Starting HTML to Markdown conversion");
+    logger.LogInformation("Input Directory: {Dir}", options.InputDirectory);
+    logger.LogInformation("Output Directory: {Dir}", options.OutputDirectory);
+
+    var progress = new Progress<ConversionProgress>(p =>
+    {
+        logger.LogInformation(
+            "Conversion Progress: {Processed}/{Total} ({Percent:F1}%) - Success: {Success}, Failed: {Failed}",
+            p.ProcessedFiles, p.TotalFiles, p.PercentComplete,
+            p.SuccessfulConversions, p.FailedConversions);
+    });
+
+    var articles = await converter.ConvertAllAsync(progress);
+
+    logger.LogInformation("Conversion complete. Total articles: {Count}", articles.Count);
+
+    foreach (var article in articles)
+    {
+        logger.LogInformation("  - {Title} [{Categories}] -> {Path}",
+            article.Title,
+            string.Join(", ", article.Categories),
+            article.OutputFilePath);
+    }
+}
+
+static async Task RunFullPipelineAsync(IServiceProvider services)
+{
+    var logger = services.GetRequiredService<ILogger<Program>>();
+
+    logger.LogInformation("Running full pipeline: Download + Convert");
+
+    await RunDownloadAsync(services);
+    await RunConvertAsync(services);
+
+    logger.LogInformation("Full pipeline complete");
+}
+
+static void PrintHelp()
+{
+    Console.WriteLine("""
+                      Archive.org Downloader & Markdown Converter
+                      ==========================================
+
+                      Commands:
+                        download    Download archived pages from Archive.org
+                        convert     Convert downloaded HTML to Markdown
+                        full        Run full pipeline (download + convert)
+                        help        Show this help message
+
+                      Configuration (appsettings.json):
+
+                        {
+                          "ArchiveOrg": {
+                            "TargetUrl": "https://example.com",
+                            "EndDate": "2024-01-01",
+                            "StartDate": null,              // null = ALL pages (greedy mode)
+                            "OutputDirectory": "./archive-output",
+                            "RateLimitMs": 5000,            // 5 seconds between requests
+                            "UniqueUrlsOnly": true,
+                            "IncludePatterns": [],
+                            "ExcludePatterns": [".*\\.js$", ".*\\.css$"]
+                          },
+                          "MarkdownConversion": {
+                            "InputDirectory": "./archive-output",
+                            "OutputDirectory": "./markdown-output",
+                            "ContentSelector": "article",   // CSS selector for main content
+                            "GenerateTags": true,
+                            "ExtractDates": true
+                          },
+                          "Ollama": {
+                            "BaseUrl": "http://localhost:11434",
+                            "Model": "llama3.2",
+                            "Enabled": true,
+                            "MaxTags": 5
+                          }
+                        }
+
+                      Examples:
+                        dotnet run -- download
+                        dotnet run -- convert
+                        dotnet run -- full
+
+                        # Override config via command line:
+                        dotnet run -- download --ArchiveOrg:TargetUrl=https://myblog.com --ArchiveOrg:EndDate=2023-12-31
+                      """);
+}
+
+// Make Program class accessible for generic logger
+public partial class Program;

--- a/Mostlylucid.ArchiveOrg/ServiceExtensions.cs
+++ b/Mostlylucid.ArchiveOrg/ServiceExtensions.cs
@@ -1,0 +1,47 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Mostlylucid.ArchiveOrg.Config;
+using Mostlylucid.ArchiveOrg.Services;
+using Polly;
+using Polly.Extensions.Http;
+
+namespace Mostlylucid.ArchiveOrg;
+
+public static class ServiceExtensions
+{
+    /// <summary>
+    /// Add all Archive.org downloader services
+    /// </summary>
+    public static IServiceCollection AddArchiveOrgServices(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        // Register configuration
+        services.Configure<ArchiveOrgOptions>(configuration.GetSection(ArchiveOrgOptions.SectionName));
+        services.Configure<MarkdownConversionOptions>(configuration.GetSection(MarkdownConversionOptions.SectionName));
+        services.Configure<OllamaOptions>(configuration.GetSection(OllamaOptions.SectionName));
+
+        // HTTP clients with retry policies
+        var retryPolicy = HttpPolicyExtensions
+            .HandleTransientHttpError()
+            .WaitAndRetryAsync(3, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)));
+
+        services.AddHttpClient<ICdxApiClient, CdxApiClient>()
+            .AddPolicyHandler(retryPolicy);
+
+        services.AddHttpClient<IArchiveDownloader, ArchiveDownloader>()
+            .AddPolicyHandler(retryPolicy)
+            .ConfigureHttpClient(client =>
+            {
+                client.DefaultRequestHeaders.Add("User-Agent",
+                    "Mostlylucid-ArchiveOrg-Downloader/1.0 (https://github.com/scottgal/mostlylucidweb)");
+            });
+
+        services.AddHttpClient<IOllamaTagGenerator, OllamaTagGenerator>();
+
+        services.AddHttpClient<IHtmlToMarkdownConverter, HtmlToMarkdownConverter>()
+            .AddPolicyHandler(retryPolicy);
+
+        return services;
+    }
+}

--- a/Mostlylucid.ArchiveOrg/Services/ArchiveDownloader.cs
+++ b/Mostlylucid.ArchiveOrg/Services/ArchiveDownloader.cs
@@ -1,0 +1,223 @@
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Mostlylucid.ArchiveOrg.Config;
+using Mostlylucid.ArchiveOrg.Models;
+
+namespace Mostlylucid.ArchiveOrg.Services;
+
+public partial class ArchiveDownloader : IArchiveDownloader
+{
+    private readonly HttpClient _httpClient;
+    private readonly ICdxApiClient _cdxApiClient;
+    private readonly ArchiveOrgOptions _options;
+    private readonly ILogger<ArchiveDownloader> _logger;
+    private readonly SemaphoreSlim _rateLimiter;
+    private DateTime _lastRequestTime = DateTime.MinValue;
+
+    public ArchiveDownloader(
+        HttpClient httpClient,
+        ICdxApiClient cdxApiClient,
+        IOptions<ArchiveOrgOptions> options,
+        ILogger<ArchiveDownloader> logger)
+    {
+        _httpClient = httpClient;
+        _cdxApiClient = cdxApiClient;
+        _options = options.Value;
+        _logger = logger;
+        _rateLimiter = new SemaphoreSlim(_options.MaxConcurrentDownloads);
+    }
+
+    public async Task<List<DownloadResult>> DownloadAllAsync(
+        IProgress<DownloadProgress>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        var results = new List<DownloadResult>();
+
+        // Ensure output directory exists
+        Directory.CreateDirectory(_options.OutputDirectory);
+
+        // Get all CDX records
+        _logger.LogInformation("Fetching CDX records for {Url}", _options.TargetUrl);
+        var records = await _cdxApiClient.GetCdxRecordsAsync(
+            _options.TargetUrl,
+            _options.StartDate,
+            _options.EndDate,
+            cancellationToken);
+
+        if (records.Count == 0)
+        {
+            _logger.LogWarning("No records found for URL: {Url}", _options.TargetUrl);
+            return results;
+        }
+
+        _logger.LogInformation("Found {Count} records to download", records.Count);
+
+        var progressReport = new DownloadProgress { TotalRecords = records.Count };
+
+        foreach (var record in records)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            progressReport.CurrentUrl = record.OriginalUrl;
+            progress?.Report(progressReport);
+
+            var result = await DownloadRecordAsync(record, cancellationToken);
+            results.Add(result);
+
+            progressReport.ProcessedRecords++;
+            if (result.Success)
+                progressReport.SuccessfulDownloads++;
+            else
+                progressReport.FailedDownloads++;
+
+            progress?.Report(progressReport);
+
+            _logger.LogInformation(
+                "Progress: {Processed}/{Total} ({Percent:F1}%) - {Url}",
+                progressReport.ProcessedRecords,
+                progressReport.TotalRecords,
+                progressReport.PercentComplete,
+                record.OriginalUrl);
+        }
+
+        return results;
+    }
+
+    public async Task<DownloadResult> DownloadRecordAsync(
+        CdxRecord record,
+        CancellationToken cancellationToken = default)
+    {
+        await _rateLimiter.WaitAsync(cancellationToken);
+
+        try
+        {
+            // Enforce rate limiting
+            await EnforceRateLimitAsync(cancellationToken);
+
+            // Generate output filename
+            var fileName = GenerateFileName(record);
+            var filePath = Path.Combine(_options.OutputDirectory, fileName);
+
+            // Skip if already downloaded
+            if (File.Exists(filePath))
+            {
+                _logger.LogDebug("Skipping already downloaded: {Url}", record.OriginalUrl);
+                return DownloadResult.Succeeded(record, filePath);
+            }
+
+            _logger.LogDebug("Downloading: {Url} from {WaybackUrl}", record.OriginalUrl, record.WaybackRawUrl);
+
+            // Download from Wayback Machine (use raw URL to avoid JS modifications)
+            var response = await _httpClient.GetAsync(record.WaybackRawUrl, cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                var error = $"HTTP {(int)response.StatusCode}: {response.ReasonPhrase}";
+                _logger.LogWarning("Failed to download {Url}: {Error}", record.OriginalUrl, error);
+                return DownloadResult.Failed(record, error);
+            }
+
+            var content = await response.Content.ReadAsStringAsync(cancellationToken);
+
+            // Clean up Wayback Machine artifacts from the HTML
+            content = CleanWaybackArtifacts(content);
+
+            // Write to file with metadata
+            await WriteHtmlFileAsync(filePath, record, content, cancellationToken);
+
+            _logger.LogDebug("Downloaded: {Url} -> {FilePath}", record.OriginalUrl, filePath);
+            return DownloadResult.Succeeded(record, filePath, content);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error downloading {Url}", record.OriginalUrl);
+            return DownloadResult.Failed(record, ex.Message);
+        }
+        finally
+        {
+            _rateLimiter.Release();
+        }
+    }
+
+    private async Task EnforceRateLimitAsync(CancellationToken cancellationToken)
+    {
+        var timeSinceLastRequest = DateTime.UtcNow - _lastRequestTime;
+        var requiredDelay = TimeSpan.FromMilliseconds(_options.RateLimitMs);
+
+        if (timeSinceLastRequest < requiredDelay)
+        {
+            var delay = requiredDelay - timeSinceLastRequest;
+            _logger.LogDebug("Rate limiting: waiting {Delay}ms", delay.TotalMilliseconds);
+            await Task.Delay(delay, cancellationToken);
+        }
+
+        _lastRequestTime = DateTime.UtcNow;
+    }
+
+    private string GenerateFileName(CdxRecord record)
+    {
+        // Create a safe filename from the URL
+        var uri = new Uri(record.OriginalUrl);
+        var pathPart = uri.AbsolutePath.Trim('/').Replace('/', '_');
+
+        if (string.IsNullOrEmpty(pathPart))
+            pathPart = "index";
+
+        // Sanitize the filename
+        var invalidChars = Path.GetInvalidFileNameChars();
+        foreach (var c in invalidChars)
+        {
+            pathPart = pathPart.Replace(c, '_');
+        }
+
+        // Add timestamp to ensure uniqueness
+        return $"{pathPart}_{record.Timestamp}.html";
+    }
+
+    private static string CleanWaybackArtifacts(string html)
+    {
+        // Remove Wayback Machine toolbar and scripts
+        html = WaybackToolbarRegex().Replace(html, string.Empty);
+        html = WaybackScriptRegex().Replace(html, string.Empty);
+        html = WaybackCommentRegex().Replace(html, string.Empty);
+
+        // Remove Wayback Machine URL rewrites in href and src attributes
+        html = WaybackUrlRewriteRegex().Replace(html, "$1$2");
+
+        return html;
+    }
+
+    private static async Task WriteHtmlFileAsync(
+        string filePath,
+        CdxRecord record,
+        string content,
+        CancellationToken cancellationToken)
+    {
+        // Add metadata comment at the top of the file
+        var metadata = $"""
+                        <!--
+                        Archive.org Download Metadata:
+                        Original URL: {record.OriginalUrl}
+                        Archive Date: {record.ArchiveDate:yyyy-MM-dd HH:mm:ss}
+                        Wayback URL: {record.WaybackUrl}
+                        Downloaded: {DateTime.UtcNow:yyyy-MM-dd HH:mm:ss} UTC
+                        -->
+                        """;
+
+        var fullContent = metadata + "\n" + content;
+        await File.WriteAllTextAsync(filePath, fullContent, cancellationToken);
+    }
+
+    [GeneratedRegex(@"<!-- BEGIN WAYBACK TOOLBAR INSERT -->.*?<!-- END WAYBACK TOOLBAR INSERT -->", RegexOptions.Singleline)]
+    private static partial Regex WaybackToolbarRegex();
+
+    [GeneratedRegex(@"<script[^>]*>.*?//playback\.archive\.org.*?</script>", RegexOptions.Singleline | RegexOptions.IgnoreCase)]
+    private static partial Regex WaybackScriptRegex();
+
+    [GeneratedRegex(@"<!--\s*FILE ARCHIVED ON.*?-->", RegexOptions.Singleline)]
+    private static partial Regex WaybackCommentRegex();
+
+    [GeneratedRegex(@"(href|src)=""https?://web\.archive\.org/web/\d+[a-z_]*/", RegexOptions.IgnoreCase)]
+    private static partial Regex WaybackUrlRewriteRegex();
+}

--- a/Mostlylucid.ArchiveOrg/Services/CdxApiClient.cs
+++ b/Mostlylucid.ArchiveOrg/Services/CdxApiClient.cs
@@ -1,0 +1,158 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Mostlylucid.ArchiveOrg.Config;
+using Mostlylucid.ArchiveOrg.Models;
+
+namespace Mostlylucid.ArchiveOrg.Services;
+
+public class CdxApiClient : ICdxApiClient
+{
+    private const string CdxApiBaseUrl = "https://web.archive.org/cdx/search/cdx";
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<CdxApiClient> _logger;
+    private readonly ArchiveOrgOptions _options;
+
+    public CdxApiClient(
+        HttpClient httpClient,
+        IOptions<ArchiveOrgOptions> options,
+        ILogger<CdxApiClient> logger)
+    {
+        _httpClient = httpClient;
+        _logger = logger;
+        _options = options.Value;
+    }
+
+    public async Task<List<CdxRecord>> GetCdxRecordsAsync(
+        string url,
+        DateTime? startDate = null,
+        DateTime? endDate = null,
+        CancellationToken cancellationToken = default)
+    {
+        var records = new List<CdxRecord>();
+
+        try
+        {
+            // Build the CDX API URL
+            var queryParams = new List<string>
+            {
+                $"url={Uri.EscapeDataString(url)}/*",
+                "output=json",
+                "fl=urlkey,timestamp,original,mimetype,statuscode,digest,length"
+            };
+
+            // Add date filters if specified
+            if (startDate.HasValue)
+            {
+                queryParams.Add($"from={startDate.Value:yyyyMMdd}");
+            }
+
+            if (endDate.HasValue)
+            {
+                queryParams.Add($"to={endDate.Value:yyyyMMdd}");
+            }
+
+            // Add MIME type filter
+            if (_options.MimeTypes.Count > 0)
+            {
+                foreach (var mimeType in _options.MimeTypes)
+                {
+                    queryParams.Add($"filter=mimetype:{mimeType}");
+                }
+            }
+
+            // Add status code filter
+            if (_options.StatusCodes.Count > 0)
+            {
+                foreach (var statusCode in _options.StatusCodes)
+                {
+                    queryParams.Add($"filter=statuscode:{statusCode}");
+                }
+            }
+
+            // Collapse to unique URLs if requested
+            if (_options.UniqueUrlsOnly)
+            {
+                queryParams.Add("collapse=urlkey");
+            }
+
+            var apiUrl = $"{CdxApiBaseUrl}?{string.Join("&", queryParams)}";
+            _logger.LogInformation("Fetching CDX records from: {Url}", apiUrl);
+
+            var response = await _httpClient.GetAsync(apiUrl, cancellationToken);
+            response.EnsureSuccessStatusCode();
+
+            var content = await response.Content.ReadAsStringAsync(cancellationToken);
+
+            if (string.IsNullOrWhiteSpace(content))
+            {
+                _logger.LogWarning("No CDX records found for URL: {Url}", url);
+                return records;
+            }
+
+            // Parse JSON array response
+            var jsonArray = JsonSerializer.Deserialize<string[][]>(content);
+            if (jsonArray == null || jsonArray.Length == 0)
+            {
+                return records;
+            }
+
+            // Skip the header row (first row contains column names)
+            foreach (var row in jsonArray.Skip(1))
+            {
+                try
+                {
+                    var record = CdxRecord.FromJsonArray(row);
+
+                    // Apply include/exclude filters
+                    if (ShouldIncludeRecord(record))
+                    {
+                        records.Add(record);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to parse CDX record: {Row}", string.Join(",", row));
+                }
+            }
+
+            _logger.LogInformation("Found {Count} CDX records for URL: {Url}", records.Count, url);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error fetching CDX records for URL: {Url}", url);
+            throw;
+        }
+
+        return records;
+    }
+
+    private bool ShouldIncludeRecord(CdxRecord record)
+    {
+        // Check include patterns
+        if (_options.IncludePatterns.Count > 0)
+        {
+            var matches = _options.IncludePatterns.Any(pattern =>
+                System.Text.RegularExpressions.Regex.IsMatch(record.OriginalUrl, pattern));
+
+            if (!matches)
+            {
+                return false;
+            }
+        }
+
+        // Check exclude patterns
+        if (_options.ExcludePatterns.Count > 0)
+        {
+            var excluded = _options.ExcludePatterns.Any(pattern =>
+                System.Text.RegularExpressions.Regex.IsMatch(record.OriginalUrl, pattern));
+
+            if (excluded)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/Mostlylucid.ArchiveOrg/Services/HtmlToMarkdownConverter.cs
+++ b/Mostlylucid.ArchiveOrg/Services/HtmlToMarkdownConverter.cs
@@ -1,0 +1,612 @@
+using System.Text.RegularExpressions;
+using System.Web;
+using HtmlAgilityPack;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Mostlylucid.ArchiveOrg.Config;
+using Mostlylucid.ArchiveOrg.Models;
+using ReverseMarkdown;
+
+namespace Mostlylucid.ArchiveOrg.Services;
+
+public partial class HtmlToMarkdownConverter : IHtmlToMarkdownConverter
+{
+    private readonly MarkdownConversionOptions _options;
+    private readonly ArchiveOrgOptions _archiveOptions;
+    private readonly IOllamaTagGenerator _tagGenerator;
+    private readonly ILogger<HtmlToMarkdownConverter> _logger;
+    private readonly Converter _markdownConverter;
+    private readonly HttpClient _httpClient;
+
+    public HtmlToMarkdownConverter(
+        IOptions<MarkdownConversionOptions> options,
+        IOptions<ArchiveOrgOptions> archiveOptions,
+        IOllamaTagGenerator tagGenerator,
+        HttpClient httpClient,
+        ILogger<HtmlToMarkdownConverter> logger)
+    {
+        _options = options.Value;
+        _archiveOptions = archiveOptions.Value;
+        _tagGenerator = tagGenerator;
+        _httpClient = httpClient;
+        _logger = logger;
+
+        // Configure ReverseMarkdown
+        _markdownConverter = new Converter(new Config
+        {
+            GithubFlavored = true,
+            RemoveComments = true,
+            SmartHrefHandling = true,
+            UnknownTags = Config.UnknownTagsOption.Bypass,
+            TableWithoutHeaderRowHandling = Config.TableWithoutHeaderRowHandlingOption.ConvertToHtmlTable
+        });
+    }
+
+    public async Task<List<MarkdownArticle>> ConvertAllAsync(
+        IProgress<ConversionProgress>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        var articles = new List<MarkdownArticle>();
+
+        // Ensure directories exist
+        Directory.CreateDirectory(_options.OutputDirectory);
+        var imagesDir = Path.Combine(_options.OutputDirectory, _options.ImagesDirectory);
+        Directory.CreateDirectory(imagesDir);
+
+        // Get all HTML files
+        var htmlFiles = Directory.GetFiles(_options.InputDirectory, _options.FilePattern, SearchOption.AllDirectories);
+        var progressReport = new ConversionProgress { TotalFiles = htmlFiles.Length };
+
+        _logger.LogInformation("Found {Count} HTML files to convert", htmlFiles.Length);
+
+        foreach (var htmlFile in htmlFiles)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            progressReport.CurrentFile = htmlFile;
+            progress?.Report(progressReport);
+
+            try
+            {
+                var article = await ConvertFileAsync(htmlFile, cancellationToken);
+                if (article != null)
+                {
+                    articles.Add(article);
+                    progressReport.SuccessfulConversions++;
+                }
+                else
+                {
+                    progressReport.FailedConversions++;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to convert {File}", htmlFile);
+                progressReport.FailedConversions++;
+            }
+
+            progressReport.ProcessedFiles++;
+            progress?.Report(progressReport);
+        }
+
+        return articles;
+    }
+
+    public async Task<MarkdownArticle?> ConvertFileAsync(
+        string htmlFilePath,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var html = await File.ReadAllTextAsync(htmlFilePath, cancellationToken);
+
+            // Extract metadata from our archive comment
+            var metadata = ExtractArchiveMetadata(html);
+
+            var doc = new HtmlDocument();
+            doc.LoadHtml(html);
+
+            // Remove unwanted elements
+            RemoveUnwantedElements(doc);
+
+            // Extract the main content
+            var contentNode = ExtractMainContent(doc);
+            if (contentNode == null)
+            {
+                _logger.LogWarning("Could not find main content in {File}", htmlFilePath);
+                return null;
+            }
+
+            // Extract title
+            var title = ExtractTitle(doc, contentNode);
+            if (string.IsNullOrEmpty(title))
+            {
+                title = Path.GetFileNameWithoutExtension(htmlFilePath);
+            }
+
+            // Rewrite links to be blog-relative
+            RewriteLinks(contentNode, metadata.originalUrl);
+
+            // Handle images
+            var images = await ProcessImagesAsync(contentNode, metadata.originalUrl, cancellationToken);
+
+            // Convert to markdown
+            var markdown = _markdownConverter.Convert(contentNode.OuterHtml);
+
+            // Clean up the markdown
+            markdown = CleanMarkdown(markdown);
+
+            // Extract or infer publish date
+            DateTime? publishDate = null;
+            if (_options.ExtractDates)
+            {
+                publishDate = ExtractPublishDate(doc, html) ?? metadata.archiveDate;
+            }
+
+            // Generate slug
+            var slug = GenerateSlug(title, metadata.originalUrl);
+
+            // Generate tags using LLM if enabled
+            List<string> categories = [];
+            if (_options.GenerateTags)
+            {
+                categories = await _tagGenerator.GenerateTagsAsync(title, markdown, cancellationToken);
+            }
+
+            var article = new MarkdownArticle
+            {
+                Title = title,
+                Slug = slug,
+                OriginalUrl = metadata.originalUrl,
+                ArchiveDate = metadata.archiveDate,
+                PublishDate = publishDate,
+                Categories = categories,
+                MarkdownContent = markdown,
+                SourceFilePath = htmlFilePath,
+                Images = images
+            };
+
+            // Write the markdown file
+            var outputPath = Path.Combine(_options.OutputDirectory, $"{slug}.md");
+            article.OutputFilePath = outputPath;
+            await File.WriteAllTextAsync(outputPath, article.ToFullMarkdown(), cancellationToken);
+
+            _logger.LogInformation("Converted: {File} -> {Output}", htmlFilePath, outputPath);
+            return article;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error converting {File}", htmlFilePath);
+            return null;
+        }
+    }
+
+    private static (string originalUrl, DateTime archiveDate) ExtractArchiveMetadata(string html)
+    {
+        var originalUrl = string.Empty;
+        var archiveDate = DateTime.MinValue;
+
+        var urlMatch = OriginalUrlRegex().Match(html);
+        if (urlMatch.Success)
+        {
+            originalUrl = urlMatch.Groups[1].Value.Trim();
+        }
+
+        var dateMatch = ArchiveDateRegex().Match(html);
+        if (dateMatch.Success && DateTime.TryParse(dateMatch.Groups[1].Value.Trim(), out var date))
+        {
+            archiveDate = date;
+        }
+
+        return (originalUrl, archiveDate);
+    }
+
+    private void RemoveUnwantedElements(HtmlDocument doc)
+    {
+        foreach (var selector in _options.RemoveSelectors)
+        {
+            var nodes = doc.DocumentNode.SelectNodes($"//{selector}") ??
+                        doc.DocumentNode.SelectNodes($"//*[contains(@class, '{selector.TrimStart('.')}')]");
+
+            if (nodes != null)
+            {
+                foreach (var node in nodes.ToList())
+                {
+                    node.Remove();
+                }
+            }
+        }
+    }
+
+    private HtmlNode? ExtractMainContent(HtmlDocument doc)
+    {
+        // Try configured selector first
+        if (!string.IsNullOrEmpty(_options.ContentSelector))
+        {
+            var node = doc.DocumentNode.SelectSingleNode($"//{_options.ContentSelector}") ??
+                       doc.DocumentNode.SelectSingleNode($"//*[contains(@class, '{_options.ContentSelector.TrimStart('.')}')]");
+            if (node != null)
+                return node;
+        }
+
+        // Try common content selectors
+        var commonSelectors = new[]
+        {
+            "//article",
+            "//main",
+            "//*[@id='content']",
+            "//*[@id='main-content']",
+            "//*[contains(@class, 'post-content')]",
+            "//*[contains(@class, 'entry-content')]",
+            "//*[contains(@class, 'article-content')]",
+            "//*[contains(@class, 'blog-post')]",
+            "//div[@role='main']"
+        };
+
+        foreach (var selector in commonSelectors)
+        {
+            var node = doc.DocumentNode.SelectSingleNode(selector);
+            if (node != null)
+                return node;
+        }
+
+        // Fall back to body
+        return doc.DocumentNode.SelectSingleNode("//body");
+    }
+
+    private static string ExtractTitle(HtmlDocument doc, HtmlNode contentNode)
+    {
+        // Try h1 in content
+        var h1 = contentNode.SelectSingleNode(".//h1");
+        if (h1 != null)
+            return HttpUtility.HtmlDecode(h1.InnerText.Trim());
+
+        // Try title tag
+        var title = doc.DocumentNode.SelectSingleNode("//title");
+        if (title != null)
+        {
+            var titleText = HttpUtility.HtmlDecode(title.InnerText.Trim());
+            // Remove common suffixes
+            var separators = new[] { " | ", " - ", " :: ", " » " };
+            foreach (var sep in separators)
+            {
+                var idx = titleText.IndexOf(sep, StringComparison.Ordinal);
+                if (idx > 0)
+                {
+                    titleText = titleText[..idx].Trim();
+                    break;
+                }
+            }
+            return titleText;
+        }
+
+        // Try og:title
+        var ogTitle = doc.DocumentNode.SelectSingleNode("//meta[@property='og:title']");
+        if (ogTitle != null)
+            return HttpUtility.HtmlDecode(ogTitle.GetAttributeValue("content", string.Empty));
+
+        return string.Empty;
+    }
+
+    private void RewriteLinks(HtmlNode contentNode, string originalUrl)
+    {
+        if (string.IsNullOrEmpty(originalUrl))
+            return;
+
+        Uri? baseUri = null;
+        try
+        {
+            baseUri = new Uri(originalUrl);
+        }
+        catch
+        {
+            return;
+        }
+
+        var targetHost = !string.IsNullOrEmpty(_archiveOptions.TargetUrl)
+            ? new Uri(_archiveOptions.TargetUrl).Host
+            : baseUri.Host;
+
+        // Rewrite all href and src attributes
+        var linksAndImages = contentNode.SelectNodes(".//*[@href or @src]");
+        if (linksAndImages == null)
+            return;
+
+        foreach (var node in linksAndImages)
+        {
+            // Handle href
+            var href = node.GetAttributeValue("href", null);
+            if (!string.IsNullOrEmpty(href))
+            {
+                var rewritten = RewriteUrl(href, baseUri, targetHost);
+                node.SetAttributeValue("href", rewritten);
+            }
+
+            // Handle src
+            var src = node.GetAttributeValue("src", null);
+            if (!string.IsNullOrEmpty(src))
+            {
+                var rewritten = RewriteUrl(src, baseUri, targetHost);
+                node.SetAttributeValue("src", rewritten);
+            }
+        }
+    }
+
+    private static string RewriteUrl(string url, Uri baseUri, string targetHost)
+    {
+        // Skip empty, mailto, tel, javascript, and anchor links
+        if (string.IsNullOrEmpty(url) ||
+            url.StartsWith("mailto:", StringComparison.OrdinalIgnoreCase) ||
+            url.StartsWith("tel:", StringComparison.OrdinalIgnoreCase) ||
+            url.StartsWith("javascript:", StringComparison.OrdinalIgnoreCase) ||
+            url.StartsWith('#'))
+        {
+            return url;
+        }
+
+        // Remove Wayback Machine URL prefix if present
+        var waybackMatch = Regex.Match(url, @"https?://web\.archive\.org/web/\d+[a-z_]*/(.+)");
+        if (waybackMatch.Success)
+        {
+            url = waybackMatch.Groups[1].Value;
+        }
+
+        // Try to parse as absolute URL
+        if (Uri.TryCreate(url, UriKind.Absolute, out var absoluteUri))
+        {
+            // If it's from the same domain, convert to relative
+            if (absoluteUri.Host.Equals(targetHost, StringComparison.OrdinalIgnoreCase) ||
+                absoluteUri.Host.Equals(baseUri.Host, StringComparison.OrdinalIgnoreCase))
+            {
+                return absoluteUri.PathAndQuery;
+            }
+
+            // External link - keep as-is
+            return url;
+        }
+
+        // Already relative or invalid - return as-is
+        return url;
+    }
+
+    private async Task<List<ImageInfo>> ProcessImagesAsync(
+        HtmlNode contentNode,
+        string originalUrl,
+        CancellationToken cancellationToken)
+    {
+        var images = new List<ImageInfo>();
+
+        if (!_options.PreserveImages)
+            return images;
+
+        var imgNodes = contentNode.SelectNodes(".//img[@src]");
+        if (imgNodes == null)
+            return images;
+
+        Uri? baseUri = null;
+        if (!string.IsNullOrEmpty(originalUrl))
+        {
+            Uri.TryCreate(originalUrl, UriKind.Absolute, out baseUri);
+        }
+
+        var imagesDir = Path.Combine(_options.OutputDirectory, _options.ImagesDirectory);
+
+        foreach (var img in imgNodes)
+        {
+            var src = img.GetAttributeValue("src", null);
+            if (string.IsNullOrEmpty(src))
+                continue;
+
+            try
+            {
+                // Resolve to absolute URL
+                var absoluteUrl = src;
+                if (!Uri.TryCreate(src, UriKind.Absolute, out var imgUri))
+                {
+                    if (baseUri != null && Uri.TryCreate(baseUri, src, out var resolvedUri))
+                    {
+                        absoluteUrl = resolvedUri.ToString();
+                    }
+                    else
+                    {
+                        continue;
+                    }
+                }
+
+                // Generate local filename
+                var fileName = GenerateImageFileName(absoluteUrl);
+                var localPath = Path.Combine(imagesDir, fileName);
+                var markdownPath = $"{_options.ImagesDirectory}/{fileName}";
+
+                var imageInfo = new ImageInfo
+                {
+                    OriginalUrl = absoluteUrl,
+                    LocalPath = localPath,
+                    MarkdownPath = markdownPath
+                };
+
+                // Download if not already exists
+                if (!File.Exists(localPath))
+                {
+                    try
+                    {
+                        var imageData = await _httpClient.GetByteArrayAsync(absoluteUrl, cancellationToken);
+                        await File.WriteAllBytesAsync(localPath, imageData, cancellationToken);
+                        imageInfo.Downloaded = true;
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "Failed to download image: {Url}", absoluteUrl);
+                    }
+                }
+                else
+                {
+                    imageInfo.Downloaded = true;
+                }
+
+                // Update the img src to the local path
+                if (imageInfo.Downloaded)
+                {
+                    img.SetAttributeValue("src", markdownPath);
+                }
+
+                images.Add(imageInfo);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Error processing image: {Src}", src);
+            }
+        }
+
+        return images;
+    }
+
+    private static string GenerateImageFileName(string url)
+    {
+        var uri = new Uri(url);
+        var fileName = Path.GetFileName(uri.AbsolutePath);
+
+        if (string.IsNullOrEmpty(fileName))
+        {
+            fileName = $"image_{Guid.NewGuid():N}.jpg";
+        }
+
+        // Sanitize filename
+        var invalidChars = Path.GetInvalidFileNameChars();
+        foreach (var c in invalidChars)
+        {
+            fileName = fileName.Replace(c, '_');
+        }
+
+        // Ensure uniqueness by adding hash
+        var hash = url.GetHashCode().ToString("X8");
+        var ext = Path.GetExtension(fileName);
+        var name = Path.GetFileNameWithoutExtension(fileName);
+
+        return $"{name}_{hash}{ext}";
+    }
+
+    private static DateTime? ExtractPublishDate(HtmlDocument doc, string html)
+    {
+        // Try common date meta tags
+        var metaSelectors = new[]
+        {
+            "//meta[@property='article:published_time']",
+            "//meta[@name='date']",
+            "//meta[@name='pubdate']",
+            "//meta[@name='DC.date.issued']",
+            "//time[@datetime]",
+            "//*[@class='date']",
+            "//*[@class='post-date']",
+            "//*[@class='entry-date']"
+        };
+
+        foreach (var selector in metaSelectors)
+        {
+            var node = doc.DocumentNode.SelectSingleNode(selector);
+            if (node != null)
+            {
+                var dateStr = node.GetAttributeValue("content", null) ??
+                              node.GetAttributeValue("datetime", null) ??
+                              node.InnerText;
+
+                if (!string.IsNullOrEmpty(dateStr) && DateTime.TryParse(dateStr, out var date))
+                {
+                    return date;
+                }
+            }
+        }
+
+        // Try to find date patterns in the HTML
+        var datePatterns = new[]
+        {
+            @"(\d{4}-\d{2}-\d{2})",
+            @"(\d{1,2}/\d{1,2}/\d{4})",
+            @"((?:January|February|March|April|May|June|July|August|September|October|November|December)\s+\d{1,2},?\s+\d{4})"
+        };
+
+        foreach (var pattern in datePatterns)
+        {
+            var match = Regex.Match(html, pattern);
+            if (match.Success && DateTime.TryParse(match.Groups[1].Value, out var date))
+            {
+                return date;
+            }
+        }
+
+        return null;
+    }
+
+    private static string GenerateSlug(string title, string originalUrl)
+    {
+        // Try to get slug from URL path first
+        if (!string.IsNullOrEmpty(originalUrl))
+        {
+            try
+            {
+                var uri = new Uri(originalUrl);
+                var path = uri.AbsolutePath.Trim('/');
+
+                // Take the last path segment as slug
+                var segments = path.Split('/', StringSplitOptions.RemoveEmptyEntries);
+                if (segments.Length > 0)
+                {
+                    var lastSegment = segments[^1];
+                    // Remove file extensions
+                    lastSegment = Path.GetFileNameWithoutExtension(lastSegment);
+                    if (!string.IsNullOrEmpty(lastSegment) && lastSegment != "index")
+                    {
+                        return SanitizeSlug(lastSegment);
+                    }
+                }
+            }
+            catch
+            {
+                // Fall through to title-based slug
+            }
+        }
+
+        // Generate from title
+        return SanitizeSlug(title);
+    }
+
+    private static string SanitizeSlug(string input)
+    {
+        // Convert to lowercase
+        var slug = input.ToLowerInvariant();
+
+        // Replace spaces and common separators with hyphens
+        slug = Regex.Replace(slug, @"[\s_]+", "-");
+
+        // Remove non-alphanumeric characters except hyphens
+        slug = Regex.Replace(slug, @"[^a-z0-9\-]", string.Empty);
+
+        // Remove multiple consecutive hyphens
+        slug = Regex.Replace(slug, @"-+", "-");
+
+        // Trim hyphens from start and end
+        slug = slug.Trim('-');
+
+        return slug;
+    }
+
+    private static string CleanMarkdown(string markdown)
+    {
+        // Remove excessive blank lines
+        markdown = Regex.Replace(markdown, @"\n{3,}", "\n\n");
+
+        // Remove trailing whitespace from lines
+        markdown = Regex.Replace(markdown, @"[ \t]+\n", "\n");
+
+        // Ensure proper spacing around headers
+        markdown = Regex.Replace(markdown, @"(\n#{1,6}\s)", "\n$1");
+
+        return markdown.Trim();
+    }
+
+    [GeneratedRegex(@"Original URL:\s*(.+?)[\r\n]")]
+    private static partial Regex OriginalUrlRegex();
+
+    [GeneratedRegex(@"Archive Date:\s*(.+?)[\r\n]")]
+    private static partial Regex ArchiveDateRegex();
+}

--- a/Mostlylucid.ArchiveOrg/Services/IArchiveDownloader.cs
+++ b/Mostlylucid.ArchiveOrg/Services/IArchiveDownloader.cs
@@ -1,0 +1,33 @@
+using Mostlylucid.ArchiveOrg.Models;
+
+namespace Mostlylucid.ArchiveOrg.Services;
+
+public interface IArchiveDownloader
+{
+    /// <summary>
+    /// Download all archived pages for a website
+    /// </summary>
+    /// <param name="progress">Optional progress reporter</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>List of download results</returns>
+    Task<List<DownloadResult>> DownloadAllAsync(
+        IProgress<DownloadProgress>? progress = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Download a single CDX record
+    /// </summary>
+    Task<DownloadResult> DownloadRecordAsync(
+        CdxRecord record,
+        CancellationToken cancellationToken = default);
+}
+
+public class DownloadProgress
+{
+    public int TotalRecords { get; set; }
+    public int ProcessedRecords { get; set; }
+    public int SuccessfulDownloads { get; set; }
+    public int FailedDownloads { get; set; }
+    public string CurrentUrl { get; set; } = string.Empty;
+    public double PercentComplete => TotalRecords > 0 ? (double)ProcessedRecords / TotalRecords * 100 : 0;
+}

--- a/Mostlylucid.ArchiveOrg/Services/ICdxApiClient.cs
+++ b/Mostlylucid.ArchiveOrg/Services/ICdxApiClient.cs
@@ -1,0 +1,20 @@
+using Mostlylucid.ArchiveOrg.Models;
+
+namespace Mostlylucid.ArchiveOrg.Services;
+
+public interface ICdxApiClient
+{
+    /// <summary>
+    /// Get all CDX records for a URL pattern from Archive.org
+    /// </summary>
+    /// <param name="url">Base URL to search (supports wildcards with *)</param>
+    /// <param name="startDate">Optional start date filter</param>
+    /// <param name="endDate">Optional end date filter</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>List of CDX records</returns>
+    Task<List<CdxRecord>> GetCdxRecordsAsync(
+        string url,
+        DateTime? startDate = null,
+        DateTime? endDate = null,
+        CancellationToken cancellationToken = default);
+}

--- a/Mostlylucid.ArchiveOrg/Services/IHtmlToMarkdownConverter.cs
+++ b/Mostlylucid.ArchiveOrg/Services/IHtmlToMarkdownConverter.cs
@@ -1,0 +1,33 @@
+using Mostlylucid.ArchiveOrg.Models;
+
+namespace Mostlylucid.ArchiveOrg.Services;
+
+public interface IHtmlToMarkdownConverter
+{
+    /// <summary>
+    /// Convert all HTML files in the input directory to Markdown
+    /// </summary>
+    /// <param name="progress">Optional progress reporter</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>List of converted articles</returns>
+    Task<List<MarkdownArticle>> ConvertAllAsync(
+        IProgress<ConversionProgress>? progress = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Convert a single HTML file to Markdown
+    /// </summary>
+    Task<MarkdownArticle?> ConvertFileAsync(
+        string htmlFilePath,
+        CancellationToken cancellationToken = default);
+}
+
+public class ConversionProgress
+{
+    public int TotalFiles { get; set; }
+    public int ProcessedFiles { get; set; }
+    public int SuccessfulConversions { get; set; }
+    public int FailedConversions { get; set; }
+    public string CurrentFile { get; set; } = string.Empty;
+    public double PercentComplete => TotalFiles > 0 ? (double)ProcessedFiles / TotalFiles * 100 : 0;
+}

--- a/Mostlylucid.ArchiveOrg/Services/IOllamaTagGenerator.cs
+++ b/Mostlylucid.ArchiveOrg/Services/IOllamaTagGenerator.cs
@@ -1,0 +1,16 @@
+namespace Mostlylucid.ArchiveOrg.Services;
+
+public interface IOllamaTagGenerator
+{
+    /// <summary>
+    /// Generate tags/categories for an article using Ollama LLM
+    /// </summary>
+    /// <param name="title">Article title</param>
+    /// <param name="content">Article content (markdown or plain text)</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>List of generated tags</returns>
+    Task<List<string>> GenerateTagsAsync(
+        string title,
+        string content,
+        CancellationToken cancellationToken = default);
+}

--- a/Mostlylucid.ArchiveOrg/Services/OllamaTagGenerator.cs
+++ b/Mostlylucid.ArchiveOrg/Services/OllamaTagGenerator.cs
@@ -1,0 +1,180 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Mostlylucid.ArchiveOrg.Config;
+
+namespace Mostlylucid.ArchiveOrg.Services;
+
+public class OllamaTagGenerator : IOllamaTagGenerator
+{
+    private readonly HttpClient _httpClient;
+    private readonly OllamaOptions _options;
+    private readonly ILogger<OllamaTagGenerator> _logger;
+
+    public OllamaTagGenerator(
+        HttpClient httpClient,
+        IOptions<OllamaOptions> options,
+        ILogger<OllamaTagGenerator> logger)
+    {
+        _httpClient = httpClient;
+        _options = options.Value;
+        _logger = logger;
+
+        _httpClient.BaseAddress = new Uri(_options.BaseUrl);
+        _httpClient.Timeout = TimeSpan.FromSeconds(_options.TimeoutSeconds);
+    }
+
+    public async Task<List<string>> GenerateTagsAsync(
+        string title,
+        string content,
+        CancellationToken cancellationToken = default)
+    {
+        if (!_options.Enabled)
+        {
+            _logger.LogDebug("Ollama tag generation is disabled");
+            return [];
+        }
+
+        try
+        {
+            // Truncate content to avoid overwhelming the model
+            var truncatedContent = content.Length > 3000 ? content[..3000] + "..." : content;
+
+            var prompt = $"""
+                          Analyze the following blog post and generate {_options.MaxTags} relevant category tags.
+
+                          Rules:
+                          - Return ONLY a JSON array of strings, nothing else
+                          - Tags should be short (1-3 words)
+                          - Tags should be relevant to the technical content
+                          - Use common programming/tech categories like: .NET, C#, ASP.NET, JavaScript, Docker, Database, API, Security, DevOps, Cloud, etc.
+                          - Do not include generic tags like "Blog", "Post", "Article"
+
+                          Title: {title}
+
+                          Content:
+                          {truncatedContent}
+
+                          Return only the JSON array:
+                          """;
+
+            var request = new OllamaGenerateRequest
+            {
+                Model = _options.Model,
+                Prompt = prompt,
+                Stream = false,
+                Options = new OllamaRequestOptions
+                {
+                    Temperature = _options.Temperature
+                }
+            };
+
+            var json = JsonSerializer.Serialize(request);
+            var httpContent = new StringContent(json, Encoding.UTF8, "application/json");
+
+            _logger.LogDebug("Sending request to Ollama for tag generation");
+            var response = await _httpClient.PostAsync("/api/generate", httpContent, cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("Ollama request failed: {StatusCode}", response.StatusCode);
+                return [];
+            }
+
+            var responseJson = await response.Content.ReadAsStringAsync(cancellationToken);
+            var ollamaResponse = JsonSerializer.Deserialize<OllamaGenerateResponse>(responseJson);
+
+            if (string.IsNullOrEmpty(ollamaResponse?.Response))
+            {
+                _logger.LogWarning("Empty response from Ollama");
+                return [];
+            }
+
+            // Parse the JSON array from the response
+            var tags = ParseTagsFromResponse(ollamaResponse.Response);
+            _logger.LogInformation("Generated tags: {Tags}", string.Join(", ", tags));
+
+            return tags;
+        }
+        catch (TaskCanceledException)
+        {
+            _logger.LogWarning("Ollama request timed out");
+            return [];
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error generating tags with Ollama");
+            return [];
+        }
+    }
+
+    private List<string> ParseTagsFromResponse(string response)
+    {
+        try
+        {
+            // Try to extract JSON array from the response
+            var trimmed = response.Trim();
+
+            // Find the start and end of the JSON array
+            var startIndex = trimmed.IndexOf('[');
+            var endIndex = trimmed.LastIndexOf(']');
+
+            if (startIndex >= 0 && endIndex > startIndex)
+            {
+                var jsonArray = trimmed.Substring(startIndex, endIndex - startIndex + 1);
+                var tags = JsonSerializer.Deserialize<List<string>>(jsonArray);
+
+                if (tags != null)
+                {
+                    // Clean up and validate tags
+                    return tags
+                        .Where(t => !string.IsNullOrWhiteSpace(t))
+                        .Select(t => t.Trim())
+                        .Where(t => t.Length >= 2 && t.Length <= 50)
+                        .Take(_options.MaxTags)
+                        .ToList();
+                }
+            }
+
+            _logger.LogWarning("Could not parse JSON array from Ollama response: {Response}", response);
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogWarning(ex, "Failed to parse Ollama response as JSON: {Response}", response);
+        }
+
+        return [];
+    }
+}
+
+internal class OllamaGenerateRequest
+{
+    [JsonPropertyName("model")]
+    public string Model { get; set; } = string.Empty;
+
+    [JsonPropertyName("prompt")]
+    public string Prompt { get; set; } = string.Empty;
+
+    [JsonPropertyName("stream")]
+    public bool Stream { get; set; }
+
+    [JsonPropertyName("options")]
+    public OllamaRequestOptions? Options { get; set; }
+}
+
+internal class OllamaRequestOptions
+{
+    [JsonPropertyName("temperature")]
+    public float Temperature { get; set; }
+}
+
+internal class OllamaGenerateResponse
+{
+    [JsonPropertyName("response")]
+    public string Response { get; set; } = string.Empty;
+
+    [JsonPropertyName("done")]
+    public bool Done { get; set; }
+}

--- a/Mostlylucid.ArchiveOrg/appsettings.json
+++ b/Mostlylucid.ArchiveOrg/appsettings.json
@@ -1,0 +1,76 @@
+{
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Microsoft": "Warning",
+        "System": "Warning"
+      }
+    }
+  },
+  "ArchiveOrg": {
+    "TargetUrl": "https://example.com",
+    "EndDate": null,
+    "StartDate": null,
+    "OutputDirectory": "./archive-output",
+    "RateLimitMs": 5000,
+    "MaxConcurrentDownloads": 1,
+    "IncludePatterns": [],
+    "ExcludePatterns": [
+      ".*\\.js$",
+      ".*\\.css$",
+      ".*\\.png$",
+      ".*\\.jpg$",
+      ".*\\.gif$",
+      ".*\\.ico$",
+      ".*\\.woff",
+      ".*\\.ttf",
+      ".*/feed/.*",
+      ".*/wp-json/.*",
+      ".*/wp-admin/.*",
+      ".*/wp-includes/.*"
+    ],
+    "UniqueUrlsOnly": true,
+    "MimeTypes": [
+      "text/html"
+    ],
+    "StatusCodes": [
+      200
+    ]
+  },
+  "MarkdownConversion": {
+    "InputDirectory": "./archive-output",
+    "OutputDirectory": "./markdown-output",
+    "ContentSelector": "",
+    "RemoveSelectors": [
+      "nav",
+      "header",
+      "footer",
+      ".sidebar",
+      ".advertisement",
+      ".ads",
+      ".comments",
+      ".social-share",
+      ".share-buttons",
+      ".related-posts",
+      ".wp-block-group",
+      "script",
+      "style",
+      "noscript",
+      "iframe"
+    ],
+    "GenerateTags": true,
+    "ExtractDates": true,
+    "FilePattern": "*.html",
+    "PreserveImages": true,
+    "ImagesDirectory": "images"
+  },
+  "Ollama": {
+    "BaseUrl": "http://localhost:11434",
+    "Model": "llama3.2",
+    "Temperature": 0.3,
+    "MaxTags": 5,
+    "TimeoutSeconds": 60,
+    "Enabled": true
+  }
+}

--- a/Mostlylucid.sln
+++ b/Mostlylucid.sln
@@ -68,6 +68,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mostlylucid.SemanticSearch"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mostlylucid.SentimentAnalysis", "Mostlylucid.SentimentAnalysis\Mostlylucid.SentimentAnalysis.csproj", "{8B9C0D1E-2F3A-4B5C-6D7E-8F9A0B1C2D3E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mostlylucid.ArchiveOrg", "Mostlylucid.ArchiveOrg\Mostlylucid.ArchiveOrg.csproj", "{9C0D1E2F-3A4B-5C6D-7E8F-9A0B1C2D3E4F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -378,6 +380,18 @@ Global
 		{8B9C0D1E-2F3A-4B5C-6D7E-8F9A0B1C2D3E}.Release|x64.Build.0 = Release|Any CPU
 		{8B9C0D1E-2F3A-4B5C-6D7E-8F9A0B1C2D3E}.Release|x86.ActiveCfg = Release|Any CPU
 		{8B9C0D1E-2F3A-4B5C-6D7E-8F9A0B1C2D3E}.Release|x86.Build.0 = Release|Any CPU
+		{9C0D1E2F-3A4B-5C6D-7E8F-9A0B1C2D3E4F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9C0D1E2F-3A4B-5C6D-7E8F-9A0B1C2D3E4F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9C0D1E2F-3A4B-5C6D-7E8F-9A0B1C2D3E4F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9C0D1E2F-3A4B-5C6D-7E8F-9A0B1C2D3E4F}.Debug|x64.Build.0 = Debug|Any CPU
+		{9C0D1E2F-3A4B-5C6D-7E8F-9A0B1C2D3E4F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9C0D1E2F-3A4B-5C6D-7E8F-9A0B1C2D3E4F}.Debug|x86.Build.0 = Debug|Any CPU
+		{9C0D1E2F-3A4B-5C6D-7E8F-9A0B1C2D3E4F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9C0D1E2F-3A4B-5C6D-7E8F-9A0B1C2D3E4F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9C0D1E2F-3A4B-5C6D-7E8F-9A0B1C2D3E4F}.Release|x64.ActiveCfg = Release|Any CPU
+		{9C0D1E2F-3A4B-5C6D-7E8F-9A0B1C2D3E4F}.Release|x64.Build.0 = Release|Any CPU
+		{9C0D1E2F-3A4B-5C6D-7E8F-9A0B1C2D3E4F}.Release|x86.ActiveCfg = Release|Any CPU
+		{9C0D1E2F-3A4B-5C6D-7E8F-9A0B1C2D3E4F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Add new Mostlylucid.ArchiveOrg project that:
- Downloads archived pages from Archive.org Wayback Machine via CDX API
- Supports rate limiting to respect Archive.org's usage limits
- Converts HTML to Markdown with automatic link rewriting (blog-relative)
- Extracts/infers publish dates from archive timestamps and HTML metadata
- Generates tags automatically using Ollama LLM integration
- Produces blog-compatible markdown format with frontmatter

Commands:
- download: Download archived pages
- convert: Convert HTML to Markdown
- full: Run complete pipeline

Configuration via appsettings.json for target URL, date ranges, content selectors, and Ollama settings.