### PR TITLE
Add broken link detection and archival feature

### DIFF
--- a/Mostlylucid.DbContext/EntityFramework/MostlylucidDBContext.cs
+++ b/Mostlylucid.DbContext/EntityFramework/MostlylucidDBContext.cs
@@ -30,6 +30,8 @@ public class MostlylucidDbContext : Microsoft.EntityFrameworkCore.DbContext, IMo
 
     public DbSet<SlugSuggestionClickEntity> SlugSuggestionClicks { get; set; }
 
+    public DbSet<BrokenLinkEntity> BrokenLinks { get; set; }
+
     protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
     {
         configurationBuilder
@@ -221,6 +223,23 @@ public class MostlylucidDbContext : Microsoft.EntityFrameworkCore.DbContext, IMo
             entity.HasIndex(x => x.ClickedAt);
 
             entity.Property(x => x.ClickedAt).HasDefaultValueSql("CURRENT_TIMESTAMP");
+        });
+
+        modelBuilder.Entity<BrokenLinkEntity>(entity =>
+        {
+            entity.ToTable("broken_links");
+            entity.HasKey(x => x.Id);
+
+            // Unique index on original URL - each URL should only be tracked once
+            entity.HasIndex(x => x.OriginalUrl).IsUnique();
+
+            // Index for finding broken links that need archive URLs
+            entity.HasIndex(x => new { x.IsBroken, x.ArchiveChecked });
+
+            // Index for finding links that need checking
+            entity.HasIndex(x => x.LastCheckedAt);
+
+            entity.Property(x => x.DiscoveredAt).HasDefaultValueSql("CURRENT_TIMESTAMP");
         });
     }
 }

--- a/Mostlylucid.Services/BrokenLinks/BrokenLinkCheckerBackgroundService.cs
+++ b/Mostlylucid.Services/BrokenLinks/BrokenLinkCheckerBackgroundService.cs
@@ -1,0 +1,180 @@
+using System.Net;
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Mostlylucid.Services.BrokenLinks;
+
+/// <summary>
+/// Background service that periodically checks links for validity and fetches archive.org URLs
+/// </summary>
+public class BrokenLinkCheckerBackgroundService : BackgroundService
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<BrokenLinkCheckerBackgroundService> _logger;
+    private readonly HttpClient _httpClient;
+    private readonly TimeSpan _checkInterval = TimeSpan.FromHours(1);
+    private const int BatchSize = 20;
+
+    public BrokenLinkCheckerBackgroundService(
+        IServiceProvider serviceProvider,
+        ILogger<BrokenLinkCheckerBackgroundService> logger,
+        IHttpClientFactory httpClientFactory)
+    {
+        _serviceProvider = serviceProvider;
+        _logger = logger;
+        _httpClient = httpClientFactory.CreateClient("BrokenLinkChecker");
+        _httpClient.Timeout = TimeSpan.FromSeconds(30);
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("Broken Link Checker Background Service started");
+
+        // Wait for app to fully initialize
+        await Task.Delay(TimeSpan.FromMinutes(5), stoppingToken);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await CheckLinksAsync(stoppingToken);
+                await FetchArchiveUrlsAsync(stoppingToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error in Broken Link Checker Background Service");
+            }
+
+            _logger.LogInformation("Broken Link Checker sleeping for {Interval}", _checkInterval);
+            await Task.Delay(_checkInterval, stoppingToken);
+        }
+
+        _logger.LogInformation("Broken Link Checker Background Service stopped");
+    }
+
+    private async Task CheckLinksAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Starting link validity check");
+
+        using var scope = _serviceProvider.CreateScope();
+        var brokenLinkService = scope.ServiceProvider.GetRequiredService<IBrokenLinkService>();
+
+        var linksToCheck = await brokenLinkService.GetLinksToCheckAsync(BatchSize, cancellationToken);
+        _logger.LogInformation("Found {Count} links to check", linksToCheck.Count);
+
+        foreach (var link in linksToCheck)
+        {
+            if (cancellationToken.IsCancellationRequested) break;
+
+            try
+            {
+                var (statusCode, isBroken, error) = await CheckUrlAsync(link.OriginalUrl, cancellationToken);
+                await brokenLinkService.UpdateLinkStatusAsync(link.Id, statusCode, isBroken, error, cancellationToken);
+
+                if (isBroken)
+                {
+                    _logger.LogWarning("Link is broken: {Url} (Status: {StatusCode})", link.OriginalUrl, statusCode);
+                }
+
+                // Small delay to be respectful to servers
+                await Task.Delay(TimeSpan.FromSeconds(2), cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error checking link: {Url}", link.OriginalUrl);
+                await brokenLinkService.UpdateLinkStatusAsync(link.Id, 0, true, ex.Message, cancellationToken);
+            }
+        }
+    }
+
+    private async Task<(int statusCode, bool isBroken, string? error)> CheckUrlAsync(string url, CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Head, url);
+            request.Headers.UserAgent.ParseAdd("Mozilla/5.0 (compatible; MostlylucidBot/1.0; +https://www.mostlylucid.net)");
+
+            using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+
+            var statusCode = (int)response.StatusCode;
+            var isBroken = response.StatusCode == HttpStatusCode.NotFound ||
+                           response.StatusCode == HttpStatusCode.Gone ||
+                           statusCode >= 500;
+
+            return (statusCode, isBroken, null);
+        }
+        catch (HttpRequestException ex)
+        {
+            return (0, true, ex.Message);
+        }
+        catch (TaskCanceledException ex) when (ex.InnerException is TimeoutException)
+        {
+            return (0, true, "Request timed out");
+        }
+    }
+
+    private async Task FetchArchiveUrlsAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Starting archive.org URL fetch");
+
+        using var scope = _serviceProvider.CreateScope();
+        var brokenLinkService = scope.ServiceProvider.GetRequiredService<IBrokenLinkService>();
+
+        var brokenLinks = await brokenLinkService.GetBrokenLinksNeedingArchiveAsync(BatchSize, cancellationToken);
+        _logger.LogInformation("Found {Count} broken links needing archive.org lookup", brokenLinks.Count);
+
+        foreach (var link in brokenLinks)
+        {
+            if (cancellationToken.IsCancellationRequested) break;
+
+            try
+            {
+                var archiveUrl = await GetArchiveUrlAsync(link.OriginalUrl, cancellationToken);
+                await brokenLinkService.UpdateArchiveUrlAsync(link.Id, archiveUrl, cancellationToken);
+
+                // Respect archive.org rate limits
+                await Task.Delay(TimeSpan.FromSeconds(5), cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error fetching archive.org URL for: {Url}", link.OriginalUrl);
+                // Mark as checked to avoid infinite retries
+                await brokenLinkService.UpdateArchiveUrlAsync(link.Id, null, cancellationToken);
+            }
+        }
+    }
+
+    private async Task<string?> GetArchiveUrlAsync(string originalUrl, CancellationToken cancellationToken)
+    {
+        // Use Wayback Machine Availability API
+        var apiUrl = $"https://archive.org/wayback/available?url={Uri.EscapeDataString(originalUrl)}";
+
+        try
+        {
+            using var response = await _httpClient.GetAsync(apiUrl, cancellationToken);
+            if (!response.IsSuccessStatusCode) return null;
+
+            var json = await response.Content.ReadAsStringAsync(cancellationToken);
+            using var document = JsonDocument.Parse(json);
+
+            var root = document.RootElement;
+            if (root.TryGetProperty("archived_snapshots", out var snapshots) &&
+                snapshots.TryGetProperty("closest", out var closest) &&
+                closest.TryGetProperty("available", out var available) &&
+                available.GetBoolean() &&
+                closest.TryGetProperty("url", out var urlElement))
+            {
+                return urlElement.GetString();
+            }
+
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to get archive.org URL for {Url}", originalUrl);
+            return null;
+        }
+    }
+}

--- a/Mostlylucid.Services/BrokenLinks/BrokenLinkService.cs
+++ b/Mostlylucid.Services/BrokenLinks/BrokenLinkService.cs
@@ -1,0 +1,123 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Mostlylucid.DbContext.EntityFramework;
+using Mostlylucid.Shared.Entities;
+
+namespace Mostlylucid.Services.BrokenLinks;
+
+/// <summary>
+/// Service for managing broken links and their archive.org replacements
+/// </summary>
+public class BrokenLinkService : IBrokenLinkService
+{
+    private readonly MostlylucidDbContext _dbContext;
+    private readonly ILogger<BrokenLinkService> _logger;
+
+    public BrokenLinkService(MostlylucidDbContext dbContext, ILogger<BrokenLinkService> logger)
+    {
+        _dbContext = dbContext;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task RegisterUrlsAsync(IEnumerable<string> urls, CancellationToken cancellationToken = default)
+    {
+        var urlList = urls.Distinct().ToList();
+        if (urlList.Count == 0) return;
+
+        // Get existing URLs
+        var existingUrls = await _dbContext.BrokenLinks
+            .Where(x => urlList.Contains(x.OriginalUrl))
+            .Select(x => x.OriginalUrl)
+            .ToListAsync(cancellationToken);
+
+        var newUrls = urlList.Except(existingUrls).ToList();
+
+        if (newUrls.Count == 0) return;
+
+        var entities = newUrls.Select(url => new BrokenLinkEntity
+        {
+            OriginalUrl = url,
+            DiscoveredAt = DateTimeOffset.UtcNow
+        }).ToList();
+
+        _dbContext.BrokenLinks.AddRange(entities);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation("Registered {Count} new URLs for broken link tracking", newUrls.Count);
+    }
+
+    /// <inheritdoc />
+    public async Task<Dictionary<string, string>> GetBrokenLinkMappingsAsync(CancellationToken cancellationToken = default)
+    {
+        return await _dbContext.BrokenLinks
+            .Where(x => x.IsBroken && x.ArchiveUrl != null)
+            .ToDictionaryAsync(
+                x => x.OriginalUrl,
+                x => x.ArchiveUrl!,
+                cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<List<BrokenLinkEntity>> GetLinksToCheckAsync(int batchSize, CancellationToken cancellationToken = default)
+    {
+        var cutoff = DateTimeOffset.UtcNow.AddHours(-24);
+
+        return await _dbContext.BrokenLinks
+            .Where(x => x.LastCheckedAt == null || x.LastCheckedAt < cutoff)
+            .OrderBy(x => x.LastCheckedAt ?? DateTimeOffset.MinValue)
+            .Take(batchSize)
+            .ToListAsync(cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task UpdateLinkStatusAsync(int linkId, int statusCode, bool isBroken, string? error = null, CancellationToken cancellationToken = default)
+    {
+        var link = await _dbContext.BrokenLinks.FindAsync(new object[] { linkId }, cancellationToken);
+        if (link == null) return;
+
+        link.LastStatusCode = statusCode;
+        link.IsBroken = isBroken;
+        link.LastCheckedAt = DateTimeOffset.UtcNow;
+        link.LastError = error;
+
+        if (isBroken)
+        {
+            link.ConsecutiveFailures++;
+        }
+        else
+        {
+            link.ConsecutiveFailures = 0;
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task UpdateArchiveUrlAsync(int linkId, string? archiveUrl, CancellationToken cancellationToken = default)
+    {
+        var link = await _dbContext.BrokenLinks.FindAsync(new object[] { linkId }, cancellationToken);
+        if (link == null) return;
+
+        link.ArchiveUrl = archiveUrl;
+        link.ArchiveChecked = true;
+        link.ArchiveCheckedAt = DateTimeOffset.UtcNow;
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        if (!string.IsNullOrEmpty(archiveUrl))
+        {
+            _logger.LogInformation("Found archive.org URL for {OriginalUrl}: {ArchiveUrl}", link.OriginalUrl, archiveUrl);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<List<BrokenLinkEntity>> GetBrokenLinksNeedingArchiveAsync(int batchSize, CancellationToken cancellationToken = default)
+    {
+        return await _dbContext.BrokenLinks
+            .Where(x => x.IsBroken && !x.ArchiveChecked)
+            .OrderBy(x => x.DiscoveredAt)
+            .Take(batchSize)
+            .ToListAsync(cancellationToken);
+    }
+}

--- a/Mostlylucid.Services/BrokenLinks/IBrokenLinkService.cs
+++ b/Mostlylucid.Services/BrokenLinks/IBrokenLinkService.cs
@@ -1,0 +1,39 @@
+using Mostlylucid.Shared.Entities;
+
+namespace Mostlylucid.Services.BrokenLinks;
+
+/// <summary>
+/// Service for managing broken links and their archive.org replacements
+/// </summary>
+public interface IBrokenLinkService
+{
+    /// <summary>
+    /// Register a collection of URLs discovered in content for tracking
+    /// </summary>
+    Task RegisterUrlsAsync(IEnumerable<string> urls, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Get all known broken links that have archive.org replacements
+    /// </summary>
+    Task<Dictionary<string, string>> GetBrokenLinkMappingsAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Get links that need to be checked for validity
+    /// </summary>
+    Task<List<BrokenLinkEntity>> GetLinksToCheckAsync(int batchSize, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Update link status after checking
+    /// </summary>
+    Task UpdateLinkStatusAsync(int linkId, int statusCode, bool isBroken, string? error = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Update the archive URL for a broken link
+    /// </summary>
+    Task UpdateArchiveUrlAsync(int linkId, string? archiveUrl, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Get broken links that need archive.org lookup
+    /// </summary>
+    Task<List<BrokenLinkEntity>> GetBrokenLinksNeedingArchiveAsync(int batchSize, CancellationToken cancellationToken = default);
+}

--- a/Mostlylucid.Shared/Entities/BrokenLinkEntity.cs
+++ b/Mostlylucid.Shared/Entities/BrokenLinkEntity.cs
@@ -1,0 +1,79 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Mostlylucid.Shared.Entities;
+
+/// <summary>
+/// Tracks external links found in blog posts and their archive.org versions
+/// </summary>
+[Table("broken_links", Schema = "mostlylucid")]
+public class BrokenLinkEntity
+{
+    [Key]
+    [Column("id")]
+    public int Id { get; set; }
+
+    /// <summary>
+    /// The original external URL found in blog content
+    /// </summary>
+    [Required]
+    [Column("original_url")]
+    [MaxLength(2048)]
+    public string OriginalUrl { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The archive.org URL for the original content (null if not yet fetched)
+    /// </summary>
+    [Column("archive_url")]
+    [MaxLength(2048)]
+    public string? ArchiveUrl { get; set; }
+
+    /// <summary>
+    /// Whether the original URL is currently broken (returns 404 or other error)
+    /// </summary>
+    [Column("is_broken")]
+    public bool IsBroken { get; set; } = false;
+
+    /// <summary>
+    /// The HTTP status code from the last check (e.g., 200, 404, 500)
+    /// </summary>
+    [Column("last_status_code")]
+    public int? LastStatusCode { get; set; }
+
+    /// <summary>
+    /// When the URL was first discovered
+    /// </summary>
+    [Column("discovered_at")]
+    public DateTimeOffset DiscoveredAt { get; set; } = DateTimeOffset.UtcNow;
+
+    /// <summary>
+    /// When the URL was last checked for validity
+    /// </summary>
+    [Column("last_checked_at")]
+    public DateTimeOffset? LastCheckedAt { get; set; }
+
+    /// <summary>
+    /// Number of consecutive check failures
+    /// </summary>
+    [Column("consecutive_failures")]
+    public int ConsecutiveFailures { get; set; } = 0;
+
+    /// <summary>
+    /// Whether archive.org has been checked for this URL
+    /// </summary>
+    [Column("archive_checked")]
+    public bool ArchiveChecked { get; set; } = false;
+
+    /// <summary>
+    /// When archive.org was last checked for this URL
+    /// </summary>
+    [Column("archive_checked_at")]
+    public DateTimeOffset? ArchiveCheckedAt { get; set; }
+
+    /// <summary>
+    /// Error message from the last check attempt (if any)
+    /// </summary>
+    [Column("last_error")]
+    [MaxLength(1000)]
+    public string? LastError { get; set; }
+}

--- a/Mostlylucid/Controllers/BrokenLinksController.cs
+++ b/Mostlylucid/Controllers/BrokenLinksController.cs
@@ -1,0 +1,41 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OutputCaching;
+using Mostlylucid.Services.BrokenLinks;
+
+namespace Mostlylucid.Controllers;
+
+/// <summary>
+/// API controller for broken link mappings used by client-side JavaScript
+/// </summary>
+[Route("api/brokenlinks")]
+[ApiController]
+public class BrokenLinksController : ControllerBase
+{
+    private readonly IBrokenLinkService _brokenLinkService;
+    private readonly ILogger<BrokenLinksController> _logger;
+
+    public BrokenLinksController(IBrokenLinkService brokenLinkService, ILogger<BrokenLinksController> logger)
+    {
+        _brokenLinkService = brokenLinkService;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Get all broken link to archive URL mappings for client-side link replacement
+    /// </summary>
+    [HttpGet("mappings")]
+    [OutputCache(Duration = 300)] // Cache for 5 minutes
+    public async Task<IActionResult> GetMappings(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var mappings = await _brokenLinkService.GetBrokenLinkMappingsAsync(cancellationToken);
+            return Ok(mappings);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error fetching broken link mappings");
+            return StatusCode(500, "Error fetching broken link mappings");
+        }
+    }
+}

--- a/Mostlylucid/Middleware/BrokenLinkArchiveMiddleware.cs
+++ b/Mostlylucid/Middleware/BrokenLinkArchiveMiddleware.cs
@@ -1,0 +1,194 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using Mostlylucid.Services.BrokenLinks;
+
+namespace Mostlylucid.Middleware;
+
+/// <summary>
+/// Middleware that collects external links from HTML responses and replaces known broken links with archive.org URLs
+/// </summary>
+public partial class BrokenLinkArchiveMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ILogger<BrokenLinkArchiveMiddleware> _logger;
+
+    // Regex to extract href attributes from anchor tags
+    [GeneratedRegex(@"<a[^>]*\shref\s*=\s*[""']([^""']+)[""'][^>]*>", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
+    private static partial Regex HrefRegex();
+
+    // List of internal URL patterns to ignore
+    private static readonly string[] InternalPatterns = { "/", "#", "mailto:", "tel:", "javascript:" };
+
+    public BrokenLinkArchiveMiddleware(RequestDelegate next, ILogger<BrokenLinkArchiveMiddleware> logger)
+    {
+        _next = next;
+        _logger = logger;
+    }
+
+    public async Task InvokeAsync(HttpContext context, IBrokenLinkService? brokenLinkService)
+    {
+        // Only process HTML responses for blog pages
+        if (!ShouldProcessRequest(context))
+        {
+            await _next(context);
+            return;
+        }
+
+        // Capture the original response body stream
+        var originalBodyStream = context.Response.Body;
+
+        using var responseBody = new MemoryStream();
+        context.Response.Body = responseBody;
+
+        await _next(context);
+
+        // Only process successful HTML responses
+        if (context.Response.StatusCode == 200 &&
+            context.Response.ContentType?.Contains("text/html", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            responseBody.Seek(0, SeekOrigin.Begin);
+            var html = await new StreamReader(responseBody).ReadToEndAsync();
+
+            if (brokenLinkService != null)
+            {
+                try
+                {
+                    // Extract and register external links
+                    var externalLinks = ExtractExternalLinks(html, context.Request);
+                    if (externalLinks.Count > 0)
+                    {
+                        // Fire and forget - don't block the response
+                        _ = Task.Run(async () =>
+                        {
+                            try
+                            {
+                                await brokenLinkService.RegisterUrlsAsync(externalLinks);
+                            }
+                            catch (Exception ex)
+                            {
+                                _logger.LogError(ex, "Error registering URLs");
+                            }
+                        });
+                    }
+
+                    // Replace known broken links with archive URLs
+                    var mappings = await brokenLinkService.GetBrokenLinkMappingsAsync(context.RequestAborted);
+                    if (mappings.Count > 0)
+                    {
+                        html = ReplaceBrokenLinks(html, mappings);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error processing broken links in response");
+                }
+            }
+
+            // Write the potentially modified response
+            var modifiedContent = Encoding.UTF8.GetBytes(html);
+            context.Response.ContentLength = modifiedContent.Length;
+
+            await originalBodyStream.WriteAsync(modifiedContent);
+        }
+        else
+        {
+            // For non-HTML responses, just copy the original response
+            responseBody.Seek(0, SeekOrigin.Begin);
+            await responseBody.CopyToAsync(originalBodyStream);
+        }
+
+        context.Response.Body = originalBodyStream;
+    }
+
+    private static bool ShouldProcessRequest(HttpContext context)
+    {
+        // Only process GET requests
+        if (!HttpMethods.IsGet(context.Request.Method)) return false;
+
+        var path = context.Request.Path.Value ?? "";
+
+        // Process blog pages and home page
+        return path.Equals("/", StringComparison.OrdinalIgnoreCase) ||
+               path.StartsWith("/blog", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private List<string> ExtractExternalLinks(string html, HttpRequest request)
+    {
+        var links = new List<string>();
+        var host = request.Host.Host;
+
+        var matches = HrefRegex().Matches(html);
+
+        foreach (Match match in matches)
+        {
+            var href = match.Groups[1].Value;
+
+            // Skip internal and special links
+            if (string.IsNullOrWhiteSpace(href)) continue;
+            if (InternalPatterns.Any(p => href.StartsWith(p, StringComparison.OrdinalIgnoreCase))) continue;
+
+            // Check if it's an external URL
+            if (Uri.TryCreate(href, UriKind.Absolute, out var uri))
+            {
+                // Skip our own domain
+                if (uri.Host.Equals(host, StringComparison.OrdinalIgnoreCase)) continue;
+                if (uri.Host.EndsWith(".mostlylucid.net", StringComparison.OrdinalIgnoreCase)) continue;
+
+                // Only track HTTP/HTTPS links
+                if (uri.Scheme == "http" || uri.Scheme == "https")
+                {
+                    links.Add(href);
+                }
+            }
+        }
+
+        return links.Distinct().ToList();
+    }
+
+    private string ReplaceBrokenLinks(string html, Dictionary<string, string> mappings)
+    {
+        var replacementCount = 0;
+
+        foreach (var (originalUrl, archiveUrl) in mappings)
+        {
+            if (html.Contains(originalUrl))
+            {
+                // Replace href="original" with href="archive" and add data attribute for transparency
+                var originalPattern = $"href=\"{originalUrl}\"";
+                var archivePattern = $"href=\"{archiveUrl}\" data-original-url=\"{originalUrl}\" title=\"Original link unavailable - archived version\"";
+
+                var newHtml = html.Replace(originalPattern, archivePattern);
+
+                // Also handle single quotes
+                var originalPatternSingle = $"href='{originalUrl}'";
+                var archivePatternSingle = $"href='{archiveUrl}' data-original-url='{originalUrl}' title='Original link unavailable - archived version'";
+
+                newHtml = newHtml.Replace(originalPatternSingle, archivePatternSingle);
+
+                if (newHtml != html)
+                {
+                    replacementCount++;
+                    html = newHtml;
+                }
+            }
+        }
+
+        if (replacementCount > 0)
+        {
+            _logger.LogInformation("Replaced {Count} broken links with archive.org URLs", replacementCount);
+        }
+
+        return html;
+    }
+}
+
+/// <summary>
+/// Extension methods for registering the broken link archive middleware
+/// </summary>
+public static class BrokenLinkArchiveMiddlewareExtensions
+{
+    public static IApplicationBuilder UseBrokenLinkArchive(this IApplicationBuilder builder)
+    {
+        return builder.UseMiddleware<BrokenLinkArchiveMiddleware>();
+    }
+}

--- a/Mostlylucid/Program.cs
+++ b/Mostlylucid/Program.cs
@@ -14,6 +14,7 @@ using Mostlylucid.Shared.Config;
 using Mostlylucid.SemanticSearch.Config;
 using Mostlylucid.SemanticSearch.Extensions;
 using Mostlylucid.SemanticSearch.Services;
+using Mostlylucid.Services.BrokenLinks;
 
 try
 {  Log.Logger = new LoggerConfiguration()
@@ -102,6 +103,11 @@ try
 
     // Popular posts polling service
     services.AddHostedService<PopularPostsPollingService>();
+
+    // Broken link detection and archive.org replacement service
+    services.AddHttpClient("BrokenLinkChecker");
+    services.AddScoped<IBrokenLinkService, BrokenLinkService>();
+    services.AddHostedService<BrokenLinkCheckerBackgroundService>();
 
     services.AddImageSharp().Configure<PhysicalFileSystemCacheOptions>(options => options.CacheFolder = "cache");
     services.SetupEmail(config);
@@ -236,6 +242,9 @@ try
     app.UseCors("AllowMostlylucid");
     app.UseAuthentication();
     app.UseAuthorization();
+
+    // Broken link archive middleware - collects external links and replaces broken ones with archive.org URLs
+    app.UseBrokenLinkArchive();
 
     if (app.Environment.IsDevelopment())
     {

--- a/Mostlylucid/src/css/main.css
+++ b/Mostlylucid/src/css/main.css
@@ -716,3 +716,21 @@ select[name="pageSize"]:focus {
         filter: invert(1) hue-rotate(180deg) !important;
     }
 }
+
+/* Archived Links - visual indicator for links that have been replaced with archive.org versions */
+a.archived-link {
+    @apply relative;
+}
+
+a.archived-link::after {
+    content: '';
+    @apply inline-block w-3 h-3 ml-1 opacity-60;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='currentColor'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4m0 5c0 2.21-3.582 4-8 4s-8-1.79-8-4'/%3E%3C/svg%3E");
+    background-size: contain;
+    background-repeat: no-repeat;
+    vertical-align: middle;
+}
+
+a.archived-link:hover::after {
+    @apply opacity-100;
+}

--- a/Mostlylucid/src/js/broken-links.js
+++ b/Mostlylucid/src/js/broken-links.js
@@ -1,0 +1,94 @@
+/**
+ * Broken Link Rewriter Module
+ * Fetches broken link mappings from the API and rewrites links on the page
+ * Works in conjunction with BrokenLinkArchiveMiddleware for a belt-and-suspenders approach
+ */
+
+// Cache for link mappings to avoid repeated API calls
+let linkMappingsCache = null;
+let lastFetchTime = 0;
+const CACHE_DURATION_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Fetch broken link mappings from the API
+ * @returns {Promise<Object>} Dictionary of originalUrl -> archiveUrl
+ */
+async function fetchLinkMappings() {
+    const now = Date.now();
+
+    // Return cached data if still fresh
+    if (linkMappingsCache && (now - lastFetchTime) < CACHE_DURATION_MS) {
+        return linkMappingsCache;
+    }
+
+    try {
+        const response = await fetch('/api/brokenlinks/mappings');
+        if (!response.ok) {
+            console.warn('Failed to fetch broken link mappings:', response.status);
+            return {};
+        }
+
+        linkMappingsCache = await response.json();
+        lastFetchTime = now;
+        return linkMappingsCache;
+    } catch (error) {
+        console.warn('Error fetching broken link mappings:', error);
+        return {};
+    }
+}
+
+/**
+ * Rewrite broken links in the given container
+ * @param {Element} container - DOM element to search for links
+ */
+async function rewriteBrokenLinks(container = document) {
+    const mappings = await fetchLinkMappings();
+
+    if (Object.keys(mappings).length === 0) {
+        return; // No mappings to apply
+    }
+
+    // Find all anchor tags
+    const links = container.querySelectorAll('a[href]');
+    let rewriteCount = 0;
+
+    links.forEach(link => {
+        const originalHref = link.getAttribute('href');
+
+        // Skip if already processed or is an archive link
+        if (link.hasAttribute('data-original-url')) return;
+        if (originalHref.includes('archive.org')) return;
+
+        // Check if this link has a mapping
+        const archiveUrl = mappings[originalHref];
+        if (archiveUrl) {
+            // Store original URL as data attribute
+            link.setAttribute('data-original-url', originalHref);
+            link.setAttribute('href', archiveUrl);
+            link.setAttribute('title', 'Original link unavailable - archived version');
+
+            // Add visual indicator (optional - can be styled via CSS)
+            link.classList.add('archived-link');
+
+            rewriteCount++;
+        }
+    });
+
+    if (rewriteCount > 0) {
+        console.log(`Rewrote ${rewriteCount} broken links to archive.org URLs`);
+    }
+}
+
+/**
+ * Initialize broken link rewriting
+ * Should be called on page load and after HTMX swaps
+ */
+function initBrokenLinks(container = document) {
+    // Don't block - run in background
+    rewriteBrokenLinks(container).catch(err => {
+        console.warn('Error in broken link rewriter:', err);
+    });
+}
+
+// Export functions for use in main.js
+export { initBrokenLinks, rewriteBrokenLinks, fetchLinkMappings };

--- a/Mostlylucid/src/js/main.js
+++ b/Mostlylucid/src/js/main.js
@@ -33,6 +33,7 @@ import { codeeditor } from "./simplemde_editor";
 import { globalSetup } from "./global";
 import  {comments} from  "./comments";
 import { queryParamClearer, queryParamToggler } from "./query-params";
+import { initBrokenLinks } from "./broken-links";
 // removed bare import of package to avoid TS source resolution
 
 window.mostlylucid.comments = comments();
@@ -53,6 +54,7 @@ window.queryParamToggler = queryParamToggler;
 // Also expose on mostlylucid namespace for backwards compatibility
 window.mostlylucid.queryParamClearer = queryParamClearer;
 window.mostlylucid.queryParamToggler = queryParamToggler;
+window.mostlylucid.initBrokenLinks = initBrokenLinks;
 
 // Track Alpine initialization to prevent duplicate starts
 let alpineStarted = false;
@@ -209,6 +211,13 @@ function registerHTMXListener() {
             console.error('Failed to set logout link:', err);
         }
 
+        // Rewrite any broken links in the swapped content
+        try {
+            initBrokenLinks(evt.detail.target);
+        } catch (err) {
+            console.error('Failed to rewrite broken links:', err);
+        }
+
         console.log('HTMX afterSettle complete for:', targetId);
     }, { once: false }); // Don't use once - we need this for all HTMX swaps
 
@@ -281,6 +290,13 @@ async function initializePage() {
         updateMetaUrls();
     } catch (err) {
         console.error('Failed to set logout link or update meta URLs:', err);
+    }
+
+    // Initialize broken link rewriter (runs in background, non-blocking)
+    try {
+        initBrokenLinks();
+    } catch (err) {
+        console.error('Failed to initialize broken links:', err);
     }
 
     console.log('Document is ready - all initializations complete');


### PR DESCRIPTION
Implements a comprehensive system for detecting broken external links in blog posts and automatically replacing them with archive.org cached versions:

- BrokenLinkEntity: stores original URLs, archive URLs, and link status
- BrokenLinkService: manages link registration, status updates, and mappings
- BrokenLinkCheckerBackgroundService: periodically checks links and fetches archive URLs
- BrokenLinkArchiveMiddleware: collects links from HTML and replaces broken ones
- BrokenLinksController: API endpoint for client-side link mappings
- JavaScript module: client-side link rewriting for HTMX dynamic content
- CSS: visual indicator for archived links

The system works in two ways:
1. Server-side: middleware modifies HTML before sending to client
2. Client-side: JavaScript rewrites links after HTMX content swaps

Note: EF migration needs to be created when dotnet CLI is available